### PR TITLE
Add corpus analysis scripts for the Parquet exporter schema

### DIFF
--- a/analysis/.gitignore
+++ b/analysis/.gitignore
@@ -1,0 +1,2 @@
+# Downloaded inputs and generated outputs (reproduced by the scripts).
+data/

--- a/analysis/COMPARISONS.md
+++ b/analysis/COMPARISONS.md
@@ -1,0 +1,135 @@
+# Designing an LLM-facing OCDS dataset — notes vs. OpenTender & Kingfisher Summarize
+
+**Status: raw notes for a future blog post, not published prose.** Captures *why* the Cardinal
+Parquet schema (issue [#129](https://github.com/open-contracting/cardinal-rs/issues/129);
+full spec in [`FINDINGS.md`](FINDINGS.md) Part 5) diverges from two existing OCDS-to-tabular
+designs. Two source artifacts sit beside this file: [`../opentender.md`](../opentender.md)
+(OpenTender's bulk CSV schema) and Kingfisher Summarize's
+[database docs](https://kingfisher-summarize.readthedocs.io/en/latest/database.html).
+
+## Thesis
+
+> The right shape for an OCDS analytical dataset is decided by **who queries it**. Three
+> real designs, three different consumers, three different shapes — and the differences are
+> not arbitrary taste, they fall out of the consumer.
+
+- **OpenTender CSV** → consumer is a **human/tool loading a bulk dump** into their own store.
+  One giant denormalized row per `buyer × lot × bid × bidder`; ~70 precomputed indicator scores;
+  every price in national **and** EUR.
+- **Kingfisher Summarize (KS)** → consumer is an **analyst writing SQL** against a Postgres DB.
+  Compiled-release grain + child summary tables; precomputed `total_*`/`sum_*`; full **JSONB**
+  kept as an escape hatch; **no** indicators (that is Cardinal's job in the OCP stack).
+- **Cardinal Parquet (ours)** → consumer is an **LLM doing guarded text-to-SQL**, run locally by
+  a user with their own key. Narrow star-ish schema; the LLM prompt is the cost function.
+
+One-liner for the post: **our artifact ≈ KS's denormalization layer ∪ Cardinal's indicator
+layer, then narrowed for an LLM.**
+
+## Side-by-side
+
+| dimension | OpenTender CSV | Kingfisher Summarize | Cardinal Parquet (ours) | why we chose ours |
+|---|---|---|---|---|
+| **consumer** | bulk interchange / spreadsheet | analyst SQL (Postgres) | LLM text-to-SQL (local) | the prompt is "the model's whole world" |
+| **grain** | 1 row / buyer×lot×bid×bidder (cartesian) | 1 / compiled release + child tables | 5 fact tables at clean grains (process/award/bid/lot/org) | cartesian ⇒ `COUNT(*)` double-count minefield for an LLM |
+| **arrays** | fully exploded into one row | child summary tables + `total_*` counts + JSONB freq maps | child tables for genuinely-multi; 1:1 arrays flattened; counts on the spine | join fan-out is the #1 LLM-SQL hazard |
+| **indicators** | ~70, as opaque 0–100 scores | none | Cardinal's 11, as interpretable bool/score, at 2 grains | precompute the un-SQL-able; stay narrow; interpretable for the zero-hallucination veto |
+| **currency** | national **+ EUR** always | summed, currency **ignored** (documented caveat) | null-on-mixed + FX (`amount_usd`) later | correctness over convenience; cross-currency = refusal until FX |
+| **coverage / missingness** | `TRANSPARENCY_*_MISSING` indicators | `field_counts` table + per-row `field_list` | per-row `has_*` flags **+** `field_coverage` table | coverage must be *queryable data* to drive graceful refusal |
+| **raw-data escape hatch** | — | full **JSONB** (never lose a field) | **excluded** | raw nested JSON is prompt poison; narrow beats complete |
+| **status filtering** | some `is*` flags | not emphasized | `*_status` first-class (indicator stability forces it) | Cardinal only scores all-awards-final processes |
+| **scope key** | `tender_country` | collection id | `dataset_id` (datasets aren't national) | 26 countries have >1 dataset; grouping by country double-counts |
+
+## Decision-by-decision reasoning (blog body material)
+
+### 1. Grain & normalization — reject the cartesian row
+OpenTender's one-row-per-`buyer×lot×bid×bidder` is fine for a human re-loading a dump, but for
+text-to-SQL it means every "how many tenders" needs `COUNT(DISTINCT tender_id)` and every
+`SUM(price)` fans out by bidder. KS avoids this with child summary tables; we do too. **The
+cartesian shape is the anti-pattern our design principle #2 is written against.** Ours and KS
+independently land on the same house style (compiled-release/process spine + child tables with
+composite keys), which is the strongest signal it's right for OCDS.
+
+### 2. Indicators — precompute the un-computable, but stay interpretable & narrow
+- OpenTender ships ~70 indicators as **0–100 scores**. KS ships **none**. We ship **Cardinal's
+  11**, as booleans/scores.
+- The real argument for precomputing isn't "nuance a naive query misses" — it's that these are
+  `f64` **outlier / percentile / concentration** scores over the *whole corpus* (e.g. R024/R025
+  ratios, R038 disqualified-bid concentration). A guarded single-`SELECT`, `LIMIT 1000` agent
+  **structurally cannot** reproduce them. So precomputing is the *only* correct path, and the
+  strongest guard for the "zero hallucinated numbers" veto.
+- But we reject OpenTender's **70-column wall** (violates narrow-beats-complete) and its **opaque
+  0–100 scores** (an LLM can't reason about `INTEGRITY_SINGLE_BID = 100`; it understands
+  `single_bid = true`). Interpretable + few.
+- Nuance we surfaced that neither comparator has: the 11 indicators live at **two grains** (8
+  per-process, 3 organization-only), which is *why* we added an `organization` table.
+
+### 3. Currency — correctness over convenience
+OpenTender always carries EUR; KS sums and openly **ignores currency**. Both cross-border
+comparison stories are either "pre-converted" (OpenTender) or "silently wrong" (KS). We take the
+strict middle: `*_currency = null` when a process mixes currencies (so a `SUM` is only valid when
+non-null), and treat cross-currency questions as an **intentional graceful-refusal** case until a
+real `amount_usd` lands (live FX to be pulled from another OCP project). We're not inventing a
+problem — we're refusing to hide the one KS documents.
+
+### 4. Coverage / missingness — must be queryable, both row- and dataset-level
+All three treat coverage as first-class, three ways: OpenTender as `*_MISSING` indicators, KS as
+a `field_counts` table + per-row `field_list`, us as per-row `has_*` flags **plus** (borrowed
+from KS) a per-dataset `field_coverage` catalog. The dataset-level table is what lets refusal be
+*data-driven* ("can you answer X for dataset 63?") rather than guessed. Both of ours derive from
+Cardinal's `coverage` output, so row flag and catalog can't disagree.
+
+### 5. Raw-data escape hatch — the thing we consciously give up
+KS keeps full JSONB so an analyst never hits a wall. We **exclude** raw nested JSON: every column
+is prompt cost, and an unread JSONB column is a standing invitation for the LLM to `json_extract`
+its way into a wrong answer. The cost of "narrow beats complete" is real — a question about a
+dropped field is unanswerable for us and answerable for KS — and that's the correct trade for a
+prompt-bound consumer. Worth stating plainly in the post as the honest downside.
+
+### 6. Status — a load-bearing filter the comparators under-emphasize
+Cardinal only computes indicators over processes whose awards are **all final** (`active` counts,
+`cancelled`/`unsuccessful` skipped, one `pending` drops the process). That forces `*_status` to
+be a first-class filter dimension, and measures to be computed on the active/final subset (null,
+never `0`, when the gate fails). Neither comparator makes status this central — it's a
+consequence of fusing the indicator layer in.
+
+### 7. Scope & identity — datasets are not countries
+Registry reality: **134 datasets / 72 countries, 26 countries with >1** (Mexico 18, Nigeria 13),
+many subnational or single-agency. So `country` is not a scope key; every table carries
+`dataset_id`, and the bot scopes by it. KS keys by collection id (same instinct); OpenTender's
+country-centric CSV would double-count here.
+
+### 8. Lossiness discipline — a small idea neither formalizes
+We pair every truncating aggregation with a **per-row flag + a count** (`supplier_truncated` +
+`supplier_count`, `contract_truncated` + `contract_count`, `main_class_source`, `lot_multi`, …)
+and state the method once in the data dictionary. KS's JSONB makes this unnecessary (nothing is
+lost); OpenTender doesn't do it. For a *narrowed* dataset it's essential — the model must see, per
+row, when a value was derived.
+
+## Borrowed vs. rejected (quick ledger)
+
+- **From KS — borrowed:** compiled-release spine + child tables (convergent); `field_coverage`
+  (from their `field_counts`); `first_award_date`/`last_award_date` (their `first_*`/`last_*`);
+  org-grain tables are normal (their `parties_summary`/`tenderers_summary`).
+- **From KS — rejected:** JSONB payload columns & frequency maps (prompt poison); `--field-lists`
+  / `release_type` polymorphism (Postgres concerns, not ours).
+- **From OpenTender — borrowed (as a *pattern*, not a copy):** indicators-as-data.
+- **From OpenTender — rejected:** cartesian single row; 70-indicator wall; opaque 0–100 scores;
+  EU-specific columns (SME/foreign-bid counts, NUTS geography) our corpus can't support anyway
+  (a good negative control confirming our coverage-driven pruning).
+- **From OpenTender — reconsidered & adopted independently:** estimated `tender_value_*` (their
+  estimated-vs-final enables price-deviation) and `*_status` importance.
+
+## Candidate blog angles / titles
+
+- "Schema design is downstream of the consumer: the same OCDS, three shapes."
+- "Narrow beats complete: why an LLM dataset is *not* a smaller analyst dataset."
+- "Precompute what SQL can't: shipping corruption-risk indicators as columns."
+- "Coverage is data: designing for graceful refusal."
+- "What we deliberately threw away (and why the JSONB escape hatch had to go)."
+
+## Sources
+
+- OpenTender CSV schema — [`../opentender.md`](../opentender.md).
+- Kingfisher Summarize DB — https://kingfisher-summarize.readthedocs.io/en/latest/database.html
+- Corpus evidence & full schema — [`FINDINGS.md`](FINDINGS.md).
+- Cardinal indicators — `src/indicators/r*.rs`; grain map in `FINDINGS.md` Part 5.

--- a/analysis/FINDINGS.md
+++ b/analysis/FINDINGS.md
@@ -35,6 +35,38 @@ registered extensions (287).
 - The 107 non-schema arrays classify cleanly as ignorable: `/auctions[]` (not in OCDS 1.1 core;
   `prepare` already has `move_auctions`), `/award[]` (one publisher's singular-key bug), etc.
 
+### Contracts merge onto awards (the merge is correct regardless of per-award fan-out)
+
+Each OCDS contract carries exactly one `contracts[]/awardID` (contract→award is N:1). Coverage
+gives element counts, so we can compute the ratio `#contracts[] / #awards[]` — but that is only
+the **mean contracts per award**, *not the distribution*. It cannot tell 0-vs-multi apart: some
+awards have **0** contracts, others **several**, and an average hides both. Formally a mean `m`
+only upper-bounds the share of awards with ≥2 contracts at `m/2` — **tight corpus-wide** (0.21 ⇒
+≤~10% of awards can be multi-contract) but **weak for the POC pair** (~0.9 ⇒ up to ~45% *could*
+be), so coverage data **cannot establish the truncation rate** for Paraguay/Rwanda. The true
+per-award fan-out needs grouping `contracts[]` by `awardID` on the **bulk sample** — a build-time
+check, not derivable here.
+
+| scope | awards[] | contracts[] | mean/award | awardID present |
+|---|---|---|---|---|
+| **corpus** | 48.0 M | 10.1 M | **0.21** | **99.7%** of contracts |
+| Paraguay DNCP (63, POC) | 282,207 | 276,496 | 0.98 | 91% |
+| Rwanda RPPA (145, POC) | 52,923 | 46,028 | 0.87 | 98% |
+| Dominican Rep. DGCP (22) | 189,939 | 232,551 | 1.22 | 100% |
+| Poder Judicial (16) | 9,688 | 15,692 | 1.62 (max) | 100% |
+
+What the numbers *do* establish: contracts are far sparser than awards overall (mean 0.21), only
+**57/91** datasets publish any `contracts[]`, and `awardID` is near-universal (99.7%) so the merge
+key is reliable (minus ~9% of Paraguay contracts that lack it → unmerged, null `contract_*`).
+
+**Why the merge is sound anyway:** it is **correct-by-construction for 0 / 1 / N contracts per
+award** — 0 ⇒ null `contract_*`; 1 ⇒ merged; N ⇒ first kept + `contract_count` +
+`contract_truncated`. So the schema does **not** depend on "≤1 per award"; the cardinality
+question is only *how often `contract_truncated` fires* (a completeness stat to read off the
+built sample), not whether the merge is valid. Reuse of `prepare`'s `awardID → contract` map and
+`award_status_by_contract_status` correction (`src/lib.rs:802–872`) is available but **opt-in**
+(see next note).
+
 ## Part 2 — field coverage that changes the schema
 
 | field | datasets | processes | note |
@@ -130,38 +162,143 @@ Bulgaria): high R-flag support, low usability support, no `numberOfTenderers`.
    carries a per-row flag **and** a count, and the method is stated once in the data dictionary
    (see the ledger below). The bot must be able to see, per row, when a value was derived.
 
+### Prior art
+
+Two OCDS-to-tabular designs were cross-checked (full reasoning + a future-blog write-up in
+[`COMPARISONS.md`](COMPARISONS.md)): **Kingfisher Summarize** (OCP's OCDS→Postgres summary layer —
+same house style: compiled-release grain, child summary tables, precomputed `total_*`/`sum_*`, a
+first-class `field_counts` coverage table; but keeps full JSONB and ships *no* indicators) and
+**OpenTender** (a single denormalized bulk CSV with ~70 precomputed indicator scores + dual
+national/EUR amounts). Our schema is, in one line, **KS-style denormalization ∪ Cardinal
+indicators, narrowed for an LLM consumer** — the borrowings (`field_coverage`, first/last award
+date) and the rejections (JSONB escape hatch, cartesian fan-out, 70-column indicator wall) are
+recorded there.
+
 ### Tables
 
 | table | grain | in POC | note |
 |---|---|---|---|
-| `contracting_process` | 1 / ocid | ✅ | the spine; dims + measures + flags + coverage flags |
-| `award` | 1 / award | ✅ | money + supplier; suppliers collapsed in |
+| `contracting_process` | 1 / ocid | ✅ | the spine; dims + measures + status + 8 per-process indicators + coverage flags |
+| `award` | 1 / award | ✅ | money + supplier + **linked contract merged via `awardID`**; suppliers collapsed in |
 | `bid` | 1 / bid | ✅ (coverage-gated, 42/93 datasets) | tenderers collapsed in |
 | `lot` | 1 / lot | ✅ **(added — see reversal)** | awards/bids attach here via `relatedLots` |
+| `organization` | 1 / (org, role) | ✅ **(added — homes the 3 org-grain indicators)** | grain mirrors Cardinal's `(Group, id)` results (roles expanded, no loss); resolved region/identifier + org-grain indicator scores; **not** a `parties[]` dump |
+| `field_coverage` | 1 / (dataset, field) | ✅ **(added — meta, not a fact table)** | per-dataset coverage catalog (KS `field_counts` analog) — drives precise graceful refusal; populated from Cardinal `coverage` |
 | `item` | 1 / item | ⛔ deferred | fan-out max ~200/process; classification captured via computed `main_class_*` instead |
-| `parties` | — | ⛔ not a table | resolved into buyer/supplier rows (see Part 3 Q5) |
+| `contract` (standalone) | 1 / contract | ⛔ merged, not standalone | contracts/awards ≤ 1 for the POC pair (Part 1) → merged onto `award`; promote only if a fan-out publisher (Dom Rep 1.22) is added |
 
-### Column checklist (concrete, for the Rust exporter)
+### Column checklist (concrete, for the Rust exporter — the authoritative spec)
 
-- **contracting_process**: `ocid` PK · `country` · `year` · `buyer_id` · `buyer_name` ·
+> This checklist is the **single source of truth** for the exporter schema; issue #129 links
+> here rather than restating it.
+
+- **contracting_process**: `ocid` PK · `dataset_id` `publisher` `dataset_title`
+  *(registry identity — `country` alone is **not** a dataset key; see dataset-scope note)* ·
+  `country` · `year` · `buyer_id` · `buyer_name` ·
   `buyer_region` `buyer_identifier` *(resolved from parties)* · `procurement_method` ·
   `procurement_method_details` · `main_procurement_category` · `tender_title` ·
-  `tender_start_date` · `tender_end_date` · `award_date` · `tender_class_scheme`
-  `tender_class_id` *(from `/tender/classification`, tenderClassification extension)* ·
-  `main_class_scheme` `main_class_id` `main_class_source` *(computed fallback from items)* ·
-  `num_tenderers` · `num_bids` · `single_bid` (bool, nullable) · `single_bid_source` ·
-  `num_awards` · `award_amount_total` · `award_currency` (null if mixed) · `supplier_count` ·
-  `num_lots` · `amendment_count` · `has_amendment` · coverage flags `has_bids`
-  `has_tenderer_count` `has_amount` `has_amendments`.
-- **award**: `ocid` FK · `award_id` · `award_status` · `award_date` · `supplier_id` ·
-  `supplier_name` · `supplier_region` `supplier_identifier` *(resolved)* · `supplier_count` ·
-  `supplier_truncated` · `amount` · `currency` · `lot_id` · `lot_multi` · denormalized dims
-  `country` `year` `procurement_method` `main_procurement_category` `buyer_id` `buyer_name`.
+  `tender_status` *(filter dimension — see status note)* · `tender_start_date` ·
+  `tender_end_date` · `first_award_date` `last_award_date` *(min/max over awards — a process can
+  have several awards on different dates; single `award_date` would be lossy, cf. KS
+  `first_award_date`/`last_award_date`)* · `tender_class_scheme` `tender_class_id`
+  *(from `/tender/classification`, tenderClassification extension)* · `main_class_scheme`
+  `main_class_id` `main_class_source` *(computed fallback from items)* · `tender_value_amount`
+  `tender_value_currency` *(estimated value; nullable — 75/93 datasets, 38% of processes)* ·
+  `num_tenderers` · `num_bids` · `num_awards` · `award_amount_total` *(active awards only)* ·
+  `award_currency` (null if mixed) · `supplier_count` · `num_lots` · `amendment_count` ·
+  `has_amendment` · **per-process indicators** `single_bid` (=R018, bool nullable) ·
+  `single_bid_source` · `r003` `r024` `r028` `r030` `r035` `r036` `r058` *(nullable f64 —
+  see indicator note)* · coverage flags `has_bids` `has_tenderer_count` `has_amount`
+  `has_amendments` `has_tender_value`.
+- **award**: `ocid` FK · `award_id` · `award_status` *(filter dimension)* · `award_date` ·
+  `supplier_id` · `supplier_name` · `supplier_region` `supplier_identifier` *(resolved)* ·
+  `supplier_count` · `supplier_truncated` · `amount` · `currency` · **linked contract (merged
+  via `awardID`)** `contract_id` `contract_status` `contract_value_amount`
+  `contract_value_currency` `contract_date_signed` `contract_period_end` `contract_count`
+  `contract_truncated` · `lot_id` · `lot_multi` · denormalized dims `dataset_id` `country` `year`
+  `procurement_method` `main_procurement_category` `buyer_id` `buyer_name`.
 - **bid**: `ocid` FK · `bid_id` · `status` · `amount` · `currency` · `tenderer_id` ·
   `tenderer_name` · `tenderer_count` · `tenderer_truncated` · `lot_id` · denormalized dims
-  `country` `year` `procurement_method` `buyer_id`.
+  `dataset_id` `country` `year` `procurement_method` `buyer_id`.
 - **lot**: `ocid` FK · `lot_id` · `lot_title` · `lot_status` · `lot_amount` · `lot_currency` ·
-  denormalized `country` `year`.
+  denormalized `dataset_id` `country` `year`.
+- **organization** *(grain 1/(org, role) — one row per Cardinal `(Group, id)` result, roles
+  **expanded not reduced** so no loss)*: PK `(dataset_id, org_id, role)` ·
+  `role` (`buyer`|`procuringEntity`|`tenderer`|`supplier`) · `name` · `region` · `identifier` ·
+  `country` · **org-grain indicators** (nullable f64) `r025` `r048` `r038_buyer`
+  `r038_procuringentity` `r038_tenderer` + the tenderer aggregates of `r024` `r028` `r030` `r035`
+  `r058`. Indicator columns populate directly from Cardinal's `results[(Group, id)]` map; **there
+  is no `Supplier` group** (suppliers are the winning subset of tenderers), so `supplier` rows
+  carry null indicator scores — they exist for id→name/region resolution, not for flags.
+- **field_coverage** *(meta table — the bot queries it to decide answerability, it is not in
+  every query)*: `dataset_id` · `field_path` (OCDS pointer, e.g. `/tender/numberOfTenderers`) ·
+  `processes_present` · `coverage` (fraction of the dataset's processes) · `mean_cardinality`
+  *(nullable — array paths only)* · `covered` (bool at a threshold). Populated from Cardinal's
+  `coverage` output — the *same* source as the per-row `has_*` flags, so the row-level flag and
+  the dataset-level catalog can't disagree. Modelled on KS's first-class `field_counts` table
+  (`collection_id, path, object_property, array_count, distinct_releases`); it lets graceful
+  refusal be data-driven ("is `numberOfTenderers` present for dataset 63?") instead of guessed.
+
+### Cardinal indicators — all 11, at two grains (measured from `set_result!` targets)
+
+Cardinal implements 11 red flags (`src/indicators/r*.rs`). They are **not** re-derivable by the
+guarded text-to-SQL agent — they are `f64` outlier / percentile / concentration scores computed
+over the *whole corpus* (single-`SELECT`, `LIMIT 1000` queries cannot reproduce them) — so they
+are **precomputed columns**. But they don't share a grain (`results: IndexMap<Group, …>`,
+`src/indicators/mod.rs`):
+
+- **8 emit a per-process (`Group::OCID`) result** → columns on `contracting_process`: R003,
+  R018, R024, R028, R030, R035, R036, R058.
+- **3 are organization-only** (no per-process value) → `organization` table: R025 (tenderer),
+  R048 (tenderer), R038 (buyer/procuringEntity/tenderer).
+- 5 of the OCID flags **also** emit a tenderer aggregate (R024/R028/R030/R035/R058) → those
+  columns live in `organization` too; per-process↔flagged-org linkage is in the
+  `ocid_tenderer_r0NN` maps.
+
+All indicator columns are **nullable and inherit the status/coverage gate**: Cardinal only
+computes them over processes whose awards are all final, so `pending`/mixed-status and
+bid-poor processes yield null, never a misleading `0`.
+
+### Status is a load-bearing filter (not decoration)
+
+Cardinal itself only computes indicators over processes whose awards are *all final*
+(`src/lib.rs:382–388`): `active` counts, `cancelled`/`unsuccessful` are ignored, a single
+`pending` award drops the whole process. So `tender_status` / `award_status` / `contract_status`
+/ `lot_status` are exported as filter dimensions, the data dictionary instructs the bot to
+exclude pending/unsuccessful/cancelled rows, and process measures (`award_amount_total`,
+`single_bid`, `r0NN`) are computed on the active/final subset. *(Note: if the exporter reuses
+`prepare`'s opt-in `award_status_by_contract_status` correction, the exported `award_status`
+reflects that correction — a cancelled contract flips its award to `cancelled` — not the raw
+source value; state this in the data dictionary so numbers reconcile with raw OCDS.)*
+
+### `prepare` transforms are opt-in — configure per dataset, not one global build
+
+Every `prepare` transform is an **opt-in setting** (`Corrections`, `Modifications`, `Defaults`,
+`Redactions`, `Exclusions` in `src/indicators/mod.rs` — all `Option`), so **none run unless
+configured**: the `awardID → contract` map + status correction, party-role resolution, id
+prefixing (`prefix_tenderer_or_supplier_id`), currency / award-status / item-classification-scheme
+defaults, `move_auctions`, etc. In practice each dataset has its own data-quality quirks, so the
+export build carries a **per-dataset Cardinal settings file** (alongside the `country`/`publisher`
+build params), not a single global config. The exporter must therefore *not assume* any transform
+already ran — it either enables the needed settings per dataset or extracts the field itself.
+Consequence for the schema: resolved columns (`buyer_region`, `supplier_identifier`, merged
+`contract_*`, corrected `*_status`) are populated only when that dataset's config enables the
+corresponding transform; otherwise they fall back to raw-source or null (a coverage gap, flagged,
+never a wrong value).
+
+### Registry datasets are not all national — `country` is not a dataset key
+
+publications.json holds **134 datasets across 72 countries**; **26 countries have >1 dataset**
+(Mexico **18**, Nigeria **13**, UK 5, Italy/Honduras 4…), **88 datasets in multi-dataset
+countries**. Many are **subnational or single-agency** (Mexico's list is largely state
+transparency institutes, "Municipio de Guadalajara", state secretariats), with **overlapping or
+disjoint scopes** — so summing/grouping by `country` across datasets double-counts or blends
+incomparable scopes. Therefore every table carries a **`dataset_id`** (registry `id`) plus
+`publisher`/`dataset_title` on the spine, and the data dictionary instructs the bot to scope
+by `dataset_id` (not `country`) unless a cross-dataset question is explicitly intended and the
+scopes are known disjoint. Government level (national / subnational / agency) is **not** in
+registry metadata — like `country`, it can only be supplied as a build-time param per dataset if
+wanted; it is *not* inferrable from `publications.json`.
 
 ### Reversal: lots ARE in the POC
 
@@ -197,11 +334,48 @@ publishers (CPV ≠ UNSPSC ≠ national codes).
 |---|---|---|
 | award keeps first of N suppliers | `supplier_truncated`, `supplier_count` | "one `award` row per award; `supplier_id/name` is the first of `supplier_count`" |
 | bid keeps first tenderer | `tenderer_truncated`, `tenderer_count` | "bid is 1:1 with tenderer for ~97% of rows; else first of `tenderer_count`" |
-| main classification derived | `main_class_source` (`tender_classification`\|`items_modal`\|null) | "computed as value-weighted modal item classification when `/tender/classification` absent" |
-| amount summed across currencies | `award_currency` = null when mixed | "`award_amount_total` valid only when `award_currency` non-null; no FX in POC" |
+| award keeps first of N contracts | `contract_truncated`, `contract_count` | "contract merged via `awardID`; ≤1 per award for the POC pair (Part 1); else first of `contract_count`. Contracts lacking `awardID` (~9% Paraguay) stay unmerged ⇒ null `contract_*`" |
+| main classification derived | `main_class_source` (`tender_classification`\|`items_modal`\|null) | "computed as value-weighted modal item classification when `/tender/classification` absent" — **non-modal classes erased ⇒ audit only via sidecar** |
+| amount summed across currencies | `award_currency` / `contract_currency` = null when mixed | "`award_amount_total` valid only when `award_currency` non-null; no FX in POC (`amount_usd` future — pull live FX from another OCP project)" |
 | award→lot mapping multi | `lot_multi` | "`lot_id` is the first related lot when `lot_multi`" |
 | single-bid derivation source | `single_bid_source` | "R018-style; from numberOfTenderers, else bid/tenderer count; null ⇒ `has_tenderer_count=false`" |
+| indicator not computable | indicator column = null | "R0NN null when the process/org failed Cardinal's all-awards-final gate or lacked the required bid data — never `0`" |
 
 Principle: **column when the loss is row-specific and queryable; dictionary when it's a global
 method statement** — and always pair a truncation flag with a count so the loss is quantified,
 not just signalled.
+
+### Audit sidecar (the exporter records the *distribution* at every n→1 reduction)
+
+The `export` command emits a small per-dataset **audit sidecar** (e.g.
+`data/<dataset_id>/_audit.json`, or a tidy `_audit` table) alongside the five tables. For every
+point where it collapses n→1 it records the **cardinality distribution** — occurrences,
+share at 1, share >1 (the truncation rate), max, and a small histogram — plus, for the
+value-erasing reductions, what was dropped. Two reasons the exporter is the right place, not a
+post-hoc `GROUP BY`:
+
+1. **A mean hides the tail.** `field_coverage.mean_cardinality` gives the average; it cannot tell
+   "everything is 1" from "many 0, some many" (the exact trap behind the earlier contracts/awards
+   mean). The audit needs the *distribution*, which the exporter has for free during `fold`
+   (map-reduce-mergeable histograms).
+2. **Some reductions erase the source values**, so they are **not reconstructible from the output
+   Parquet at all** — only the exporter still sees the original array.
+
+Reduction points to record:
+
+| reduction point | reconstructible from Parquet? | what the sidecar adds |
+|---|---|---|
+| suppliers → first per award | yes (`supplier_count`) | ready-made per-dataset rate + histogram; cross-check the flag logic |
+| tenderers → first per bid | yes (`tenderer_count`) | " |
+| contracts → first per award | yes (`contract_count`) | the real per-award distribution (the mean can't settle it) |
+| related lots → first per award/bid | partly (`lot_multi` bool, **no count**) | how many lots were dropped, distribution |
+| party roles | **N/A — no reduction** (`organization` is 1/(org, role), roles expanded) | `roles_per_party` is a *confirming* census, not a loss audit |
+| **item classifications → modal** (`main_class`) | **no** | dispersion: distinct classes/process, modal share of line value |
+| any scalarized/dropped multi field (`submissionMethod`, `tender/tenderers`, `relatedProcesses`, …) | **no** | cardinality census so "scalarize/drop" is validated per dataset, not assumed |
+
+> **Resolved:** `organization` is keyed **1/(org_id, role)** — one row per Cardinal `(Group, id)`
+> result — so a party's roles are **expanded, not reduced**, and party roles are no longer a lossy
+> reduction (removed from the ledger above). Rationale: a party's role is *contextual* (buyer in
+> one process, supplier in another) and Cardinal already computes org indicators per `(Group, id)`,
+> so this grain mirrors Cardinal's output exactly. The sidecar keeps `roles_per_party` as a sanity
+> census (how many parties are multi-role) rather than a truncation audit.

--- a/analysis/FINDINGS.md
+++ b/analysis/FINDINGS.md
@@ -35,36 +35,39 @@ registered extensions (287).
 - The 107 non-schema arrays classify cleanly as ignorable: `/auctions[]` (not in OCDS 1.1 core;
   `prepare` already has `move_auctions`), `/award[]` (one publisher's singular-key bug), etc.
 
-### Contracts merge onto awards (the merge is correct regardless of per-award fan-out)
+### Contracts get their own table (fan-out makes merging lossy)
 
 Each OCDS contract carries exactly one `contracts[]/awardID` (contract→award is N:1). Coverage
 gives element counts, so we can compute the ratio `#contracts[] / #awards[]` — but that is only
 the **mean contracts per award**, *not the distribution*. It cannot tell 0-vs-multi apart: some
 awards have **0** contracts, others **several**, and an average hides both. Formally a mean `m`
-only upper-bounds the share of awards with ≥2 contracts at `m/2` — **tight corpus-wide** (0.21 ⇒
-≤~10% of awards can be multi-contract) but **weak for the POC pair** (~0.9 ⇒ up to ~45% *could*
-be), so coverage data **cannot establish the truncation rate** for Paraguay/Rwanda. The true
-per-award fan-out needs grouping `contracts[]` by `awardID` on the **bulk sample** — a build-time
-check, not derivable here.
+only upper-bounds the share of awards with ≥2 contracts at `m/2`. The **POC pair straddles both
+regimes**: Rwanda's mean 0.87 is consistent with mostly ≤1-per-award, but **Dominican Republic's
+mean is 1.22 — a genuine fan-out** (mean >1 *guarantees* multi-contract awards: ≥~11% have ≥2,
+likely more). So for this pair coverage data confirms fan-out is real for Dom Rep and needs
+grouping `contracts[]` by `awardID` on the **bulk sample** to get the exact truncation rate.
 
 | scope | awards[] | contracts[] | mean/award | awardID present |
 |---|---|---|---|---|
 | **corpus** | 48.0 M | 10.1 M | **0.21** | **99.7%** of contracts |
-| Paraguay DNCP (63, POC) | 282,207 | 276,496 | 0.98 | 91% |
 | Rwanda RPPA (145, POC) | 52,923 | 46,028 | 0.87 | 98% |
-| Dominican Rep. DGCP (22) | 189,939 | 232,551 | 1.22 | 100% |
+| **Dominican Rep. DGCP (22, POC)** | 189,939 | 232,551 | **1.22** | **100%** |
+| Paraguay DNCP (63, ex-POC) | 282,207 | 276,496 | 0.98 | 91% |
 | Poder Judicial (16) | 9,688 | 15,692 | 1.62 (max) | 100% |
 
 What the numbers *do* establish: contracts are far sparser than awards overall (mean 0.21), only
-**57/91** datasets publish any `contracts[]`, and `awardID` is near-universal (99.7%) so the merge
-key is reliable (minus ~9% of Paraguay contracts that lack it → unmerged, null `contract_*`).
+**57/91** datasets publish any `contracts[]`, and `awardID` is near-universal (99.7%; 100% for Dom
+Rep, 98% for Rwanda) so the merge key is reliable.
 
-**Why the merge is sound anyway:** it is **correct-by-construction for 0 / 1 / N contracts per
-award** — 0 ⇒ null `contract_*`; 1 ⇒ merged; N ⇒ first kept + `contract_count` +
-`contract_truncated`. So the schema does **not** depend on "≤1 per award"; the cardinality
-question is only *how often `contract_truncated` fires* (a completeness stat to read off the
-built sample), not whether the merge is valid. Reuse of `prepare`'s `awardID → contract` map and
-`award_status_by_contract_status` correction (`src/lib.rs:802–872`) is available but **opt-in**
+**Decision (resolved): `contract` is a standalone table**, not merged onto `award`. Dom Rep is
+contract-rich (232 k contracts) and fans out at 1.22/award, so merging (keep-first + truncate)
+would drop the 2nd+ contract for a material share of Dom Rep awards — losing contract
+value/status/dates that price-deviation questions need. A standalone `contract` table (1/contract,
+FK `award_id`) is **lossless**; the cost is one extra join for contract-level questions and one
+more table in the prompt. This retires the earlier merge design (and its `contract_*`-on-award
+columns, `contract_count`/`contract_truncated`, and the contract-truncation ledger row). Contracts
+are joined to awards by `(ocid, award_id)`. `prepare`'s `awardID → contract` linkage +
+`award_status_by_contract_status` correction (`src/lib.rs:802–872`) are reused but **opt-in**
 (see next note).
 
 ## Part 2 — field coverage that changes the schema
@@ -135,11 +138,17 @@ viable.**
 | 55 | Greece (OpenTender) | Greek / EU | 71,116 | 28 | 20 | 48 | |
 | 44 | Bulgaria (OpenTender) | Bulgarian / EU | 259,766 | 28 | 19 | 47 | |
 
-**Recommended contrasting pair for the first build:** **Rwanda (145)** and **Paraguay (63)** —
-top of the ranking, different language (en / es) and region (MEA / LAC), both support ~100
-indicators including R018. **Ghana (85)** is a strong English alternative. For a bid-rich but
-usability-poor contrast (tests graceful refusal), add an **OpenTender** publisher (Greece,
-Bulgaria): high R-flag support, low usability support, no `numberOfTenderers`.
+**Recommended contrasting pair for the first build:** **Rwanda (145)** and **Dominican Republic
+(22)** — different language (en / es) and region (MEA / LAC), both high on the ranking (96 / 89
+well-supported indicators) and both publish `numberOfTenderers` at ~100% (single-bid fully
+computable). This pair also exercises **every coverage gate in opposite directions**, which makes
+it a better stress test than Paraguay would have been: `bids/details` present for Dom Rep, absent
+for Rwanda; `tender/lots` present for Rwanda (1.24/tender), **absent for Dom Rep** (0.00);
+contracts fan out for Dom Rep (1.22/award), ≤1 for Rwanda (0.87). **Paraguay (63)** (rank 1, 100
+indicators, 5.74 lots/tender) remains a strong alternative if a lot-heavy or longer-history
+(2011–) dataset is wanted. **Ghana (85)** is a strong English alternative. For a bid-rich but
+usability-poor contrast, add an **OpenTender** publisher (Greece, Bulgaria): high R-flag support,
+low usability support, no `numberOfTenderers`.
 
 ## Part 5 — proposed Parquet schema (POC)
 
@@ -179,14 +188,14 @@ recorded there.
 | table | grain | in POC | note |
 |---|---|---|---|
 | `contracting_process` | 1 / ocid | ✅ | the spine; dims + measures + status + 8 per-process indicators + coverage flags |
-| `award` | 1 / award | ✅ | money + supplier + **linked contract merged via `awardID`**; suppliers collapsed in |
+| `award` | 1 / award | ✅ | money + supplier; suppliers collapsed in; contracts are their *own* table (joined by `award_id`) |
+| `contract` | 1 / contract | ✅ **(standalone — promoted; see Part 1)** | value/status/dates; FK `award_id`; Dom Rep fan-out 1.22/award makes a table lossless where a merge would truncate |
 | `bid` | 1 / bid | ✅ (coverage-gated, 42/93 datasets) | tenderers collapsed in |
 | `lot` | 1 / lot | ✅ **(added — see reversal)** | awards/bids attach here via `relatedLots` |
 | `organization` | 1 / (org, role) | ✅ **(added — homes the 3 org-grain indicators)** | grain mirrors Cardinal's `(Group, id)` results (roles expanded, no loss); resolved region/identifier + org-grain indicator scores; **not** a `parties[]` dump |
 | `field_coverage` | 1 / (dataset, field) | ✅ **(added — meta, not a fact table)** | per-dataset coverage catalog (KS `field_counts` analog) — drives precise graceful refusal; populated from Cardinal `coverage` |
 | `dataset_meta` | 1 / dataset | ✅ **(added — meta)** | dataset routing + **scope/threshold/exclusion/temporal/quality** metadata; the in-prompt catalog is generated from it; hand-curated from the registry (see below) |
 | `item` | 1 / item | ⛔ deferred | fan-out max ~200/process; classification captured via computed `main_class_*` instead |
-| `contract` (standalone) | 1 / contract | ⛔ merged, not standalone | contracts/awards ≤ 1 for the POC pair (Part 1) → merged onto `award`; promote only if a fan-out publisher (Dom Rep 1.22) is added |
 
 ### Column checklist (concrete, for the Rust exporter — the authoritative spec)
 
@@ -213,11 +222,15 @@ recorded there.
   `has_amendments` `has_tender_value`.
 - **award**: `ocid` FK · `award_id` · `award_status` *(filter dimension)* · `award_date` ·
   `supplier_id` · `supplier_name` · `supplier_region` `supplier_identifier` *(resolved)* ·
-  `supplier_count` · `supplier_truncated` · `amount` · `currency` · **linked contract (merged
-  via `awardID`)** `contract_id` `contract_status` `contract_value_amount`
-  `contract_value_currency` `contract_date_signed` `contract_period_end` `contract_count`
-  `contract_truncated` · `lot_id` · `lot_multi` · denormalized dims `dataset_id` `country` `year`
-  `procurement_method` `main_procurement_category` `buyer_id` `buyer_name`.
+  `supplier_count` · `supplier_truncated` · `amount` · `currency` · `lot_id` · `lot_multi` ·
+  denormalized dims `dataset_id` `country` `year` `procurement_method` `main_procurement_category`
+  `buyer_id` `buyer_name`. *(Contracts are a separate table, joined by `(ocid, award_id)`.)*
+- **contract** *(standalone — 1/contract)*: `ocid` FK · `award_id` FK *(from `contracts[]/awardID`)* ·
+  `contract_id` · `contract_status` *(filter dimension)* · `contract_value_amount`
+  `contract_value_currency` *(null if the contract mixes currencies)* · `contract_date_signed` ·
+  `contract_period_end` · denormalized dims `dataset_id` `country` `year`. Lossless (all contracts
+  kept — no truncation); the price-deviation chain is `tender_value_amount` (est.) → award `amount`
+  → `contract_value_amount` (final), joined award↔contract on `(ocid, award_id)`.
 - **bid**: `ocid` FK · `bid_id` · `status` · `amount` · `currency` · `tenderer_id` ·
   `tenderer_name` · `tenderer_count` · `tenderer_truncated` · `lot_id` · denormalized dims
   `dataset_id` `country` `year` `procurement_method` `buyer_id`.
@@ -238,7 +251,7 @@ recorded there.
   `coverage` output — the *same* source as the per-row `has_*` flags, so the row-level flag and
   the dataset-level catalog can't disagree. Modelled on KS's first-class `field_counts` table
   (`collection_id, path, object_property, array_count, distinct_releases`); it lets graceful
-  refusal be data-driven ("is `numberOfTenderers` present for dataset 63?") instead of guessed.
+  refusal be data-driven ("is `numberOfTenderers` present for dataset 22?") instead of guessed.
 - **dataset_meta** *(meta table, 1/dataset — the routing surface)*: `dataset_id` · `publisher` ·
   `country` · `region` · `government_level` · `date_from` · `date_to` · `currency` · `license` ·
   `n_processes` · `scope_summary` · `exclusions` · `threshold` · `methods` · `quality_notes`.
@@ -297,8 +310,8 @@ defaults, `move_auctions`, etc. In practice each dataset has its own data-qualit
 export build carries a **per-dataset Cardinal settings file** (alongside the `country`/`publisher`
 build params), not a single global config. The exporter must therefore *not assume* any transform
 already ran — it either enables the needed settings per dataset or extracts the field itself.
-Consequence for the schema: resolved columns (`buyer_region`, `supplier_identifier`, merged
-`contract_*`, corrected `*_status`) are populated only when that dataset's config enables the
+Consequence for the schema: resolved columns (`buyer_region`, `supplier_identifier`, the
+`contract` table's linkage, corrected `*_status`) are populated only when that dataset's config enables the
 corresponding transform; otherwise they fall back to raw-source or null (a coverage gap, flagged,
 never a wrong value).
 
@@ -324,7 +337,7 @@ country to its dataset(s), **filter/group by `dataset_id`, and return a row per 
 
 | question type | cross-dataset? | rule |
 |---|---|---|
-| rates / shares / counts (single-bid rate, % open, # processes) | ✅ per-dataset breakdown | comparable, but **caveat each dataset's coverage** (e.g. single-bid computable for Rwanda; only ~13% of Paraguay processes publish `numberOfTenderers`) so a thin denominator isn't read as a real rate |
+| rates / shares / counts (single-bid rate, % open, # processes) | ✅ per-dataset breakdown | comparable, but **caveat each dataset's coverage** (from `field_coverage`) so a field sparse in one dataset isn't compared as if complete — e.g. single-bid is fully computable for *this* pair (Rwanda 99.4%, Dom Rep 100% publish `numberOfTenderers`), but `bids/details` exists only for Dom Rep and `tender/lots` only for Rwanda |
 | monetary amounts / totals | ⛔ refuse (or counts-only) | different currencies, no FX — the designated graceful-refusal case until `amount_usd` |
 | fence-based indicators (R024/25/30/35/36/38/48/58) | ⛔ within-dataset only | dataset-relative baselines (see indicator baseline caveat) — cross-dataset comparison is meaningless |
 
@@ -349,33 +362,37 @@ distinct refusal ⇒ a distinct eval gold type (**scope-mismatch**).
 
 **Hand-curated `dataset_meta` (from the registry JSON-LD, 2026-07 snapshot):**
 
-| field | 63 Paraguay DNCP | 145 Rwanda RPPA |
+| field | 145 Rwanda RPPA | 22 Dominican Rep. DGCP |
 |---|---|---|
-| publisher | Dirección Nacional de Contrataciones Públicas (SICP) | Public Procurement Authority (RPPA), Umucyo portal |
-| country / region | Paraguay / LAC | Rwanda / MEA |
-| government_level | national — all bodies, national→local, all branches + SOEs | national — central + local agencies (**below-district entities not in system**) |
-| date_from / date_to | 2011-01-03 / 2026-06-18 | 2013-12-14 / 2026-04-30 |
-| currency | PYG | RWF |
-| license | CC-BY-4.0 | CC-BY-NC-SA-4.0 |
-| n_processes | ~246,320 | ~49,300 |
-| threshold | excludes purchases < 20× daily min wage (Art 35) ≈ **PYG 84,340 ≈ USD 250** (2020) | includes only processes **≥ 3,000,000 RWF** |
-| exclusions | works concessions/permits/licenses (Art 2.b); **multilateral-financed** (UNDP) & **treaty** procedures (Yacyretá, Itaipú) (Art 2.c) | **security organs procuring classified items**; **PPPs**; below-district (sectors, health centres, schools) |
-| methods | (not stated) | open, selective, direct |
-| quality_notes | threshold is 2020 value; excluded categories won't appear at all | tender+award per process; **contract data only "where available"** (cf. contracts/awards 0.87) |
+| publisher | Public Procurement Authority (RPPA), Umucyo portal | Dirección General de Contrataciones Públicas (DGCP), Portal transaccional |
+| country / region | Rwanda / MEA | Dominican Republic / LAC |
+| government_level | national — central + local agencies (**below-district entities not in system**) | national — all central + local agencies on the Transactional Portal |
+| date_from / date_to | 2013-12-14 / 2026-04-30 | **2023-07-18** / 2026-06-19 *(short history — starts mid-2023)* |
+| currency | RWF | DOP (RD$) |
+| license | CC-BY-NC-SA-4.0 | ODbL (opendatacommons.org/licenses/odbl) |
+| n_processes | ~49,300 | ~195,100 |
+| threshold | includes only processes **≥ 3,000,000 RWF** | petty-cash purchases excluded (**≤ RD$50,000**, per-expense ≤ RD$5,000) (law 340-06) |
+| exclusions | **security organs procuring classified items**; **PPPs**; below-district (sectors, health centres, schools) | terminated contracts (termination ≤ 40% of total); **foreign-service office** construction/acquisition; **exclusive/single-supplier** goods & services (law 340-06) |
+| methods | open, selective, direct | (not stated) |
+| quality_notes | tender+award per process; **contract data only "where available"** (cf. contracts/awards 0.87); no `bids/details`; has `tender/lots` (1.24) | **contracts fan out (1.22/award)** — all captured in the standalone `contract` table; has `bids/details`; **no `tender/lots`** |
 
 Rwanda's "**excludes security organs procuring classified items**" is the concrete scope-mismatch
 case for the eval: *"defence procurement in Rwanda"* must **refuse** (not return non-classified
-spend). Likewise a *"contracts under PYG 50,000 in Paraguay"* / *"under 1,000,000 RWF in Rwanda"*
-question is below the publication threshold ⇒ refuse, don't return a misleading `0`.
+spend). Likewise sub-threshold questions — *"contracts under RD$30,000 in the Dominican Republic"*
+(below the RD$50,000 petty-cash floor) / *"under 1,000,000 RWF in Rwanda"* — must refuse, not
+return a misleading `0`. And Dom Rep's **2023 start** makes temporal refusal sharp: a *"2020"*
+question is out of range for Dom Rep but answerable for Rwanda (which starts 2013).
 
 ### Reversal: lots ARE in the POC
 
 Earlier I deferred lots as EU/OpenTender-specific — **the corpus disproves that.** Non-OpenTender
-publishers set n-ary lots heavily, including both recommended datasets: **Paraguay 5.74
-lots/tender, Rwanda 1.24**, plus Brazil 8.17 and Québec 7.39. In a multi-lot tender the tender
-is one row but awards/bids each concern a *specific* lot (via `relatedLots`); dropping lots
-would blur distinct lots together and make "value by lot" impossible. A `lot` table is cheap
-(card ~2–6, versus items ~200) and analytically central, so it's in.
+publishers set n-ary lots heavily: **Paraguay 5.74 lots/tender, Rwanda 1.24**, Brazil 8.17,
+Québec 7.39. In a multi-lot tender the tender is one row but awards/bids each concern a *specific*
+lot (via `relatedLots`); dropping lots would blur distinct lots and make "value by lot"
+impossible. A `lot` table is cheap (card ~2–6, versus items ~200) and analytically central, so
+it's in — but **coverage-gated like `bid`**: in the current POC pair it's populated for **Rwanda
+(1.24)** and **empty for Dominican Republic (0.00 — DGCP doesn't use `tender/lots`)**, so the
+`lot` table is effectively Rwanda-only here (the `has_*`/`field_coverage` gate handles it).
 
 ### relatedLots → how lots connect
 
@@ -402,7 +419,6 @@ publishers (CPV ≠ UNSPSC ≠ national codes).
 |---|---|---|
 | award keeps first of N suppliers | `supplier_truncated`, `supplier_count` | "one `award` row per award; `supplier_id/name` is the first of `supplier_count`" |
 | bid keeps first tenderer | `tenderer_truncated`, `tenderer_count` | "bid is 1:1 with tenderer for ~97% of rows; else first of `tenderer_count`" |
-| award keeps first of N contracts | `contract_truncated`, `contract_count` | "contract merged via `awardID`; ≤1 per award for the POC pair (Part 1); else first of `contract_count`. Contracts lacking `awardID` (~9% Paraguay) stay unmerged ⇒ null `contract_*`" |
 | main classification derived | `main_class_source` (`tender_classification`\|`items_modal`\|null) | "computed as value-weighted modal item classification when `/tender/classification` absent" — **non-modal classes erased ⇒ audit only via sidecar** |
 | amount summed across currencies | `award_currency` / `contract_currency` = null when mixed | "`award_amount_total` valid only when `award_currency` non-null; no FX in POC (`amount_usd` future — pull live FX from another OCP project)" |
 | award→lot mapping multi | `lot_multi` | "`lot_id` is the first related lot when `lot_multi`" |
@@ -435,7 +451,7 @@ Reduction points to record:
 |---|---|---|
 | suppliers → first per award | yes (`supplier_count`) | ready-made per-dataset rate + histogram; cross-check the flag logic |
 | tenderers → first per bid | yes (`tenderer_count`) | " |
-| contracts → first per award | yes (`contract_count`) | the real per-award distribution (the mean can't settle it) |
+| contracts per award | **N/A — no reduction** (`contract` is its own table) | `contracts_per_award` is a *confirming* census (esp. Dom Rep's fan-out), not a truncation audit |
 | related lots → first per award/bid | partly (`lot_multi` bool, **no count**) | how many lots were dropped, distribution |
 | party roles | **N/A — no reduction** (`organization` is 1/(org, role), roles expanded) | `roles_per_party` is a *confirming* census, not a loss audit |
 | **item classifications → modal** (`main_class`) | **no** | dispersion: distinct classes/process, modal share of line value |

--- a/analysis/FINDINGS.md
+++ b/analysis/FINDINGS.md
@@ -1,0 +1,207 @@
+# OCDS corpus findings — input to the Cardinal Parquet schema
+
+Reproduce with the scripts in this directory (see [README.md](README.md)). Corpus:
+**93 datasets with coverage, 47.7 M contracting processes.** 220 distinct array paths observed
+(113 in-schema, 107 publisher-specific); 336 array paths are defined by OCDS 1.1 core (49) +
+registered extensions (287).
+
+## Part 1 — which arrays are 1:1 vs multi vs rare
+
+### Effectively 1:1 (flatten into a row)
+
+| array | card (corpus / med / max) | implication |
+|---|---|---|
+| `/awards[]/suppliers[]` | 1.05 / 1.01 / 3 | an award almost always has one supplier → **flatten supplier onto the award row** (keep `supplier_count` for the ~5% consortium case) |
+| `/bids/details[]/tenderers[]` | 1.03 / 1.02 / 1 | a bid is 1:1 with its tenderer → flatten |
+| `/parties[]/roles[]` | 1.16 / 1.00 / 4 | small role set |
+| `/relatedProcesses[]`, `/awards[]/relatedLots[]`, `/tender/submissionMethod[]` | ~1.0 | scalar-like |
+
+### Genuinely multi (own table or a count column)
+
+| array | card (corpus / med / max) | breadth | implication |
+|---|---|---|---|
+| `/awards[]` | 1.38 / 1.26 / 5 | 91/93 | **justifies the `award` table**; also `num_awards` on the process row |
+| `/bids/details[]` | 1.97 / 2.11 / 9 | 42/93 | `num_bids`; bid analysis (but see coverage caveat) |
+| `/tender/items[]` | 2.99 / 2.68 / **204** | 77/93 | huge fan-out — do not flatten; ignore for POC |
+| `/awards[]/items[]`, `/contracts[]/items[]` | ~2.0 / max 208 | 65 / 26 | ignore |
+| `/parties[]` | 2.50 / 2.25 / 13 | 92/93 | the org **lookup**, not a fact table; buyer/supplier already denormalized by id+name |
+| documents / milestones / transactions | 2–13 / max 170 | varies | high fan-out, non-analytical → ignore |
+
+### Rare across the corpus
+
+- **Amendments are rare:** `/contracts[]/amendments[]` 12 datasets, `/tender/amendments[]` 9,
+  `/awards[]/amendments[]` 4 → amendment-risk questions answerable in ~12/93 datasets at most.
+- Most extension arrays appear in ≤5 datasets (metrics, guarantees, enquiries, criteria, …).
+- The 107 non-schema arrays classify cleanly as ignorable: `/auctions[]` (not in OCDS 1.1 core;
+  `prepare` already has `move_auctions`), `/award[]` (one publisher's singular-key bug), etc.
+
+## Part 2 — field coverage that changes the schema
+
+| field | datasets | processes | note |
+|---|---|---|---|
+| `/tender/numberOfTenderers` | **24/93** | **12.9%** | `single_bid` (R018, `src/indicators/r018.rs`) keys on this scalar → single-bid answerable in ~¼ of the corpus |
+| `/awards[]/value/amount` | 86/93 | 82% | **source process `amount` from awards** |
+| `/tender/value/amount` | 75/93 | 38% | too sparse to rely on |
+
+**Schema implications:** flatten the 1:1 arrays; keep the `award` table (suppliers collapse
+into it); drop/merge the weak `tenderer` table into a `bid` table gated on 45% bid coverage;
+make `single_bid` nullable + a coverage flag (or add a `/bids/details[]`-derived bid-count
+fallback) rather than emitting misleading `0`s; ignore items/documents/milestones and the
+non-schema + rare-extension tail.
+
+## Part 3 — indicator support (the whole catalogue, not just single-bid)
+
+`indicator_support.py` evaluates the [Kingfisher-Colab indicator catalogue][kfc] — **71
+usability (U###) + 73 red-flag (R###) indicators** — against every dataset. Each indicator is
+a rule tree of required OCDS fields (`all` / `any` / `ref`); we map every field to a coverage
+path and score the tree (leaf = per-process coverage, `all`=min, `any`=max). *supported* = all
+required fields present at all; *well-supported* = score ≥ 0.5 (upper-bound share of processes
+computable — coverage is marginal, so true joint support is ≤ this). Full tables in
+`data/indicator_support_by_{indicator,dataset}.csv`.
+
+**Widely supportable (data almost always present):** U001/U002/U005 (procedure counts,
+buyers), R045/R046 (needs only `parties/roles`+`id`), R042/R044/R043 (bidder address/contact),
+U009/U010/U008 (procurement method / category / item type) — all well-supported in 55–84 of 84
+datasets.
+
+**Rarely supportable (fields almost nobody publishes):** R032/R033 (beneficial owners /
+shareholders), R037/R056 (bid documents + award criteria), R070 (subcontracting via related
+processes), R020 (complaints), R008/R009 (participation fees), U051/U052 (delivery
+place/date) — 0–2 datasets.
+
+**Single-bid, reframed:** as an *indicator* R018 is **well-supported in 49/84 datasets**,
+because its rule is `any(tender/numberOfTenderers, tender/tenderers/id,
+bids/details/tenderers/id, bids/statistics/value)` — not the bare scalar. Cardinal's *current
+implementation* (`src/indicators/r018.rs`) only reads `tender.numberOfTenderers` (24 datasets),
+so **most of R018's supportable corpus is left on the table** — extending R018 to the bid-based
+sources roughly doubles its reach.
+
+**Cardinal's 11 implemented red flags are mostly bid-hungry.** Only 4 are broadly supportable —
+R048 (52), R018 (49), R028 (29), R003 (18); the other seven (R024, R025, R030, R035, R036,
+R038, R058) need detailed `bids/details` value/status data and are well-supported in **≤2
+datasets**. Cardinal's red-flag reach is data-limited, not code-limited.
+
+[kfc]: https://github.com/open-contracting/kingfisher-colab/tree/315feec/ocdskingfishercolab/indicators
+
+## Part 4 — dataset subset with the best coverage (POC candidates)
+
+Ranked by **well-supported indicators** (`indicator_support.py`, `data/indicator_support_by_dataset.csv`)
+— a far richer signal than the 3-theme lens in `select_datasets.py`. **Moldova — named in the
+draft plan — has 0 processes in this snapshot, so the proposed "Moldova + LAC" pair is not
+viable.**
+
+| id | publisher | lang / region | processes | U-well /71 | R-well /73 | total | R018? |
+|---|---|---|---|---|---|---|---|
+| 63 | Paraguay DNCP | Spanish / LAC | 246,320 | 61 | 39 | **100** | ✅ |
+| 145 | Rwanda RPPA | English / MEA | 49,630 | 62 | 34 | 96 | ✅ |
+| 22 | Dominican Rep. DGCP | Spanish / LAC | 195,141 | 54 | 35 | 89 | ✅ |
+| 142 | Guatemala MFP | Spanish / LAC | 1,704,941 | 52 | 35 | 87 | ✅ |
+| 85 | Ghana PPA | English / MEA | 7,058 | 57 | 30 | 87 | ✅ |
+| 137 | Argentina DGCyGP | Spanish / LAC | 23,006 | 50 | 24 | 74 | |
+| 79 | Canada (Québec) | French / NA | 398,798 | 46 | 19 | 65 | ✅ |
+| 110 | Ecuador SERCOP | Spanish / LAC | 332,703 | 38 | 14 | 52 | |
+| 55 | Greece (OpenTender) | Greek / EU | 71,116 | 28 | 20 | 48 | |
+| 44 | Bulgaria (OpenTender) | Bulgarian / EU | 259,766 | 28 | 19 | 47 | |
+
+**Recommended contrasting pair for the first build:** **Rwanda (145)** and **Paraguay (63)** —
+top of the ranking, different language (en / es) and region (MEA / LAC), both support ~100
+indicators including R018. **Ghana (85)** is a strong English alternative. For a bid-rich but
+usability-poor contrast (tests graceful refusal), add an **OpenTender** publisher (Greece,
+Bulgaria): high R-flag support, low usability support, no `numberOfTenderers`.
+
+## Part 5 — proposed Parquet schema (POC)
+
+### Design principles
+
+1. **Narrow beats complete.** The cost of a column is not storage — Parquet is columnar and
+   dictionary-compresses repeated low-cardinality values to near-nothing, and unread columns
+   cost nothing at query time. The cost is the **LLM prompt**: the schema + data dictionary sit
+   in the (cached) system prompt as "the model's whole world," so every extra column is more
+   tokens per question and more surface for wrong-field / hallucinated SQL. Non-analytical
+   columns (raw documents, milestones, transactions, internal ids, localized display text
+   beyond one label) are therefore **excluded**, not "included because they're cheap."
+2. **Denormalize dimensions, never measures.** Repeat the filter/group-by dimensions
+   (`country`, `year`, `procurement_method`, `main_procurement_category`, `buyer_*`, `lot_id`)
+   into child tables so the common question is single-table (join fan-out is the #1 LLM-SQL
+   correctness hazard). Never copy a process-level **measure/flag** (`single_bid`, `num_bids`,
+   `award_amount_total`) onto child rows — that invites `COUNT(*)`-over-awards double counting.
+   Process measures live only on `contracting_process`; count processes with `COUNT(DISTINCT ocid)`.
+3. **Lossiness is explicit.** Any column produced by an aggregation that truncates or assumes
+   carries a per-row flag **and** a count, and the method is stated once in the data dictionary
+   (see the ledger below). The bot must be able to see, per row, when a value was derived.
+
+### Tables
+
+| table | grain | in POC | note |
+|---|---|---|---|
+| `contracting_process` | 1 / ocid | ✅ | the spine; dims + measures + flags + coverage flags |
+| `award` | 1 / award | ✅ | money + supplier; suppliers collapsed in |
+| `bid` | 1 / bid | ✅ (coverage-gated, 42/93 datasets) | tenderers collapsed in |
+| `lot` | 1 / lot | ✅ **(added — see reversal)** | awards/bids attach here via `relatedLots` |
+| `item` | 1 / item | ⛔ deferred | fan-out max ~200/process; classification captured via computed `main_class_*` instead |
+| `parties` | — | ⛔ not a table | resolved into buyer/supplier rows (see Part 3 Q5) |
+
+### Column checklist (concrete, for the Rust exporter)
+
+- **contracting_process**: `ocid` PK · `country` · `year` · `buyer_id` · `buyer_name` ·
+  `buyer_region` `buyer_identifier` *(resolved from parties)* · `procurement_method` ·
+  `procurement_method_details` · `main_procurement_category` · `tender_title` ·
+  `tender_start_date` · `tender_end_date` · `award_date` · `tender_class_scheme`
+  `tender_class_id` *(from `/tender/classification`, tenderClassification extension)* ·
+  `main_class_scheme` `main_class_id` `main_class_source` *(computed fallback from items)* ·
+  `num_tenderers` · `num_bids` · `single_bid` (bool, nullable) · `single_bid_source` ·
+  `num_awards` · `award_amount_total` · `award_currency` (null if mixed) · `supplier_count` ·
+  `num_lots` · `amendment_count` · `has_amendment` · coverage flags `has_bids`
+  `has_tenderer_count` `has_amount` `has_amendments`.
+- **award**: `ocid` FK · `award_id` · `award_status` · `award_date` · `supplier_id` ·
+  `supplier_name` · `supplier_region` `supplier_identifier` *(resolved)* · `supplier_count` ·
+  `supplier_truncated` · `amount` · `currency` · `lot_id` · `lot_multi` · denormalized dims
+  `country` `year` `procurement_method` `main_procurement_category` `buyer_id` `buyer_name`.
+- **bid**: `ocid` FK · `bid_id` · `status` · `amount` · `currency` · `tenderer_id` ·
+  `tenderer_name` · `tenderer_count` · `tenderer_truncated` · `lot_id` · denormalized dims
+  `country` `year` `procurement_method` `buyer_id`.
+- **lot**: `ocid` FK · `lot_id` · `lot_title` · `lot_status` · `lot_amount` · `lot_currency` ·
+  denormalized `country` `year`.
+
+### Reversal: lots ARE in the POC
+
+Earlier I deferred lots as EU/OpenTender-specific — **the corpus disproves that.** Non-OpenTender
+publishers set n-ary lots heavily, including both recommended datasets: **Paraguay 5.74
+lots/tender, Rwanda 1.24**, plus Brazil 8.17 and Québec 7.39. In a multi-lot tender the tender
+is one row but awards/bids each concern a *specific* lot (via `relatedLots`); dropping lots
+would blur distinct lots together and make "value by lot" impossible. A `lot` table is cheap
+(card ~2–6, versus items ~200) and analytically central, so it's in.
+
+### relatedLots → how lots connect
+
+`relatedLots` is only ever populated at `/awards[]/relatedLots[]` (43 datasets) and
+`/bids/details[]/relatedLots[]` (37), both card ~1.0. So we **denormalize the `lot_id` key**
+(not lot attributes) onto the `award` and `bid` rows; lot measures (`lot_amount`, etc.) stay in
+the `lot` table, joined by `(ocid, lot_id)` — consistent with "denormalize dimensions, not
+measures." If an award/bid maps to >1 lot (rare), keep the first and set `lot_multi`.
+
+### Tender classification (corrected)
+
+There **is** a standard single-valued tender classification — `/tender/classification`
+(id/scheme/description) from the registered **tenderClassification** extension — but it's sparse
+(**6 datasets / 10.9%**). Item-level classification is far better covered
+(`/tender/items[]/classification/id`, 70 datasets). So: populate `tender_class_*` from
+`/tender/classification` when present; otherwise **compute `main_class_*`** as the modal item
+classification per process (weighted by line value when available, else count), and record which
+was used in `main_class_source`. Keep `scheme` beside `id` and never mix schemes across
+publishers (CPV ≠ UNSPSC ≠ national codes).
+
+### Lossiness ledger (per-row flag + count, and the dictionary note)
+
+| assumption / aggregation | per-row column(s) | dictionary note (global method) |
+|---|---|---|
+| award keeps first of N suppliers | `supplier_truncated`, `supplier_count` | "one `award` row per award; `supplier_id/name` is the first of `supplier_count`" |
+| bid keeps first tenderer | `tenderer_truncated`, `tenderer_count` | "bid is 1:1 with tenderer for ~97% of rows; else first of `tenderer_count`" |
+| main classification derived | `main_class_source` (`tender_classification`\|`items_modal`\|null) | "computed as value-weighted modal item classification when `/tender/classification` absent" |
+| amount summed across currencies | `award_currency` = null when mixed | "`award_amount_total` valid only when `award_currency` non-null; no FX in POC" |
+| award→lot mapping multi | `lot_multi` | "`lot_id` is the first related lot when `lot_multi`" |
+| single-bid derivation source | `single_bid_source` | "R018-style; from numberOfTenderers, else bid/tenderer count; null ⇒ `has_tenderer_count=false`" |
+
+Principle: **column when the loss is row-specific and queryable; dictionary when it's a global
+method statement** — and always pair a truncation flag with a count so the loss is quantified,
+not just signalled.

--- a/analysis/FINDINGS.md
+++ b/analysis/FINDINGS.md
@@ -184,6 +184,7 @@ recorded there.
 | `lot` | 1 / lot | ✅ **(added — see reversal)** | awards/bids attach here via `relatedLots` |
 | `organization` | 1 / (org, role) | ✅ **(added — homes the 3 org-grain indicators)** | grain mirrors Cardinal's `(Group, id)` results (roles expanded, no loss); resolved region/identifier + org-grain indicator scores; **not** a `parties[]` dump |
 | `field_coverage` | 1 / (dataset, field) | ✅ **(added — meta, not a fact table)** | per-dataset coverage catalog (KS `field_counts` analog) — drives precise graceful refusal; populated from Cardinal `coverage` |
+| `dataset_meta` | 1 / dataset | ✅ **(added — meta)** | dataset routing + **scope/threshold/exclusion/temporal/quality** metadata; the in-prompt catalog is generated from it; hand-curated from the registry (see below) |
 | `item` | 1 / item | ⛔ deferred | fan-out max ~200/process; classification captured via computed `main_class_*` instead |
 | `contract` (standalone) | 1 / contract | ⛔ merged, not standalone | contracts/awards ≤ 1 for the POC pair (Part 1) → merged onto `award`; promote only if a fan-out publisher (Dom Rep 1.22) is added |
 
@@ -238,6 +239,13 @@ recorded there.
   the dataset-level catalog can't disagree. Modelled on KS's first-class `field_counts` table
   (`collection_id, path, object_property, array_count, distinct_releases`); it lets graceful
   refusal be data-driven ("is `numberOfTenderers` present for dataset 63?") instead of guessed.
+- **dataset_meta** *(meta table, 1/dataset — the routing surface)*: `dataset_id` · `publisher` ·
+  `country` · `region` · `government_level` · `date_from` · `date_to` · `currency` · `license` ·
+  `n_processes` · `scope_summary` · `exclusions` · `threshold` · `methods` · `quality_notes`.
+  Hand-curated from the registry dataset page (JSON-LD `description`/`temporalCoverage`/`license`,
+  which carry the "show more" scope prose); the in-prompt **dataset catalog** is generated from
+  the human-readable subset. This is what catches **scope-mismatch** questions that `field_coverage`
+  can't (the field is present, but the dataset's *scope* excludes the ask — see selection note).
 
 ### Cardinal indicators — all 11, at two grains (measured from `set_result!` targets)
 
@@ -258,6 +266,14 @@ are **precomputed columns**. But they don't share a grain (`results: IndexMap<Gr
 All indicator columns are **nullable and inherit the status/coverage gate**: Cardinal only
 computes them over processes whose awards are all final, so `pending`/mixed-status and
 bid-poor processes yield null, never a misleading `0`.
+
+**Baseline caveat — most indicators are dataset-relative, so NOT comparable across datasets.**
+The fence-based flags (R024, R025, R030, R035, R036, R038, R048, R058) are computed against
+**their own dataset's** distribution (quartiles/fences, per `indicators` run — the `Meta`), so a
+flag means "outlier *within this dataset*." Comparing their scores or flag-rates across datasets
+is near-meaningless (the outlier tail is ~fixed by construction) and a confident-but-wrong answer
+waiting to happen. Only `single_bid` (a boolean share) and `r003` (fixed threshold) are
+cross-dataset comparable. See the cross-dataset rule below.
 
 ### Status is a load-bearing filter (not decoration)
 
@@ -299,6 +315,58 @@ by `dataset_id` (not `country`) unless a cross-dataset question is explicitly in
 scopes are known disjoint. Government level (national / subnational / agency) is **not** in
 registry metadata — like `country`, it can only be supplied as a build-time param per dataset if
 wanted; it is *not* inferrable from `publications.json`.
+
+### Cross-dataset / multi-country queries — breakdown, never a blended figure
+
+When a question spans countries/datasets, the data dictionary instructs the bot to resolve each
+country to its dataset(s), **filter/group by `dataset_id`, and return a row per dataset** — never
+`GROUP BY country` across heterogeneous scopes. Answerability is gated by question type:
+
+| question type | cross-dataset? | rule |
+|---|---|---|
+| rates / shares / counts (single-bid rate, % open, # processes) | ✅ per-dataset breakdown | comparable, but **caveat each dataset's coverage** (e.g. single-bid computable for Rwanda; only ~13% of Paraguay processes publish `numberOfTenderers`) so a thin denominator isn't read as a real rate |
+| monetary amounts / totals | ⛔ refuse (or counts-only) | different currencies, no FX — the designated graceful-refusal case until `amount_usd` |
+| fence-based indicators (R024/25/30/35/36/38/48/58) | ⛔ within-dataset only | dataset-relative baselines (see indicator baseline caveat) — cross-dataset comparison is meaningless |
+
+Only `single_bid` and `r003` are safe to compare across datasets. Guardrail should deny
+cross-currency `SUM`/comparison and cross-dataset aggregation of fence-based indicator columns.
+
+### Dataset selection & the scope-mismatch hallucination
+
+*How the bot picks the dataset(s) for a question.* It reads the in-prompt **dataset catalog**
+(generated from `dataset_meta`), matches the question's geography / time window / sector-scope /
+metric, then: one dataset fits → scope to it; several fit → per-dataset breakdown (above);
+question's scope/time/geography not covered → **refuse with the reason**; ambiguous (no geography
+named) → **ask a clarifying question**. Machine-checkable facts (`date_from/date_to`, `currency`)
+are verified against `dataset_meta` and enforced by the guardrail; the catalog scales in-prompt to
+~dozens of datasets, then moves to a retrieval / discovery-query step.
+
+**Why `dataset_meta`, not just `field_coverage`:** `field_coverage` catches "the field isn't
+populated." It does **not** catch "the field is populated but the dataset's *scope* excludes the
+ask" — which produces the most dangerous answers (a plausible number that is silently wrong). Only
+the scope/threshold/exclusion/temporal metadata lets the bot refuse these. Distinct failure mode ⇒
+distinct refusal ⇒ a distinct eval gold type (**scope-mismatch**).
+
+**Hand-curated `dataset_meta` (from the registry JSON-LD, 2026-07 snapshot):**
+
+| field | 63 Paraguay DNCP | 145 Rwanda RPPA |
+|---|---|---|
+| publisher | Dirección Nacional de Contrataciones Públicas (SICP) | Public Procurement Authority (RPPA), Umucyo portal |
+| country / region | Paraguay / LAC | Rwanda / MEA |
+| government_level | national — all bodies, national→local, all branches + SOEs | national — central + local agencies (**below-district entities not in system**) |
+| date_from / date_to | 2011-01-03 / 2026-06-18 | 2013-12-14 / 2026-04-30 |
+| currency | PYG | RWF |
+| license | CC-BY-4.0 | CC-BY-NC-SA-4.0 |
+| n_processes | ~246,320 | ~49,300 |
+| threshold | excludes purchases < 20× daily min wage (Art 35) ≈ **PYG 84,340 ≈ USD 250** (2020) | includes only processes **≥ 3,000,000 RWF** |
+| exclusions | works concessions/permits/licenses (Art 2.b); **multilateral-financed** (UNDP) & **treaty** procedures (Yacyretá, Itaipú) (Art 2.c) | **security organs procuring classified items**; **PPPs**; below-district (sectors, health centres, schools) |
+| methods | (not stated) | open, selective, direct |
+| quality_notes | threshold is 2020 value; excluded categories won't appear at all | tender+award per process; **contract data only "where available"** (cf. contracts/awards 0.87) |
+
+Rwanda's "**excludes security organs procuring classified items**" is the concrete scope-mismatch
+case for the eval: *"defence procurement in Rwanda"* must **refuse** (not return non-classified
+spend). Likewise a *"contracts under PYG 50,000 in Paraguay"* / *"under 1,000,000 RWF in Rwanda"*
+question is below the publication threshold ⇒ refuse, don't return a misleading `0`.
 
 ### Reversal: lots ARE in the POC
 

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,0 +1,45 @@
+# Corpus analysis for the Parquet exporter
+
+Scripts that mine the Data Registry's published field-coverage to inform the ML-ready Parquet
+schema (issue [#129](https://github.com/open-contracting/cardinal-rs/issues/129)): which OCDS
+fields are arrays, which arrays are effectively 1:1 vs genuinely multi, which are too rare to
+model, and which datasets have the best coverage for the chatbot POC.
+
+The Data Registry already publishes Cardinal `coverage` output for every dataset in
+`publications.json`, and `coverage` counts array elements (`/awards[]`) separately from the
+processes that contain them (`/awards`), so array cardinality is derivable **without
+downloading or re-running Cardinal on any bulk data**.
+
+## Run
+
+The scripts form a pipeline: run them **in this order** — each reads the previous steps'
+outputs from `data/`, so running one standalone fails if its inputs are missing. Steps 3–6 are
+independent of each other once 1–2 have run.
+
+```bash
+cd analysis
+python3 download.py           # → publications.json, extensions.json, OCDS 1.1 schema, indicator catalogue
+python3 fetch_ext_schemas.py  # reads extensions.json      → data/ext_cache/*.json
+python3 schema_arrays.py      # reads core schema+ext_cache → data/schema_arrays.json  (legitimate array paths)
+python3 analyze.py            # reads publications+schema_arrays → data/assessment.{csv,json}  (array-field assessment)
+python3 select_datasets.py    # reads publications         → data/dataset_scores.csv  (coarse 3-theme coverage lens)
+python3 indicator_support.py  # reads publications+schema_arrays+indicators → data/indicator_support_by_{indicator,dataset}.csv
+```
+
+Pure standard-library Python 3; no third-party dependencies. `download.py` and
+`fetch_ext_schemas.py` are idempotent (skip already-downloaded files). Everything under `data/`
+is downloaded or generated and is git-ignored.
+
+## Outputs
+
+- `data/assessment.csv` — every observed array path with breadth (datasets present),
+  presence, and cardinality (corpus mean + per-dataset median/max), flagged core / extension /
+  non-schema.
+- `data/dataset_scores.csv` — every dataset (≥500 processes) scored on coverage of three POC
+  question themes (single-bid, money/supplier, amendments) — a coarse lens.
+- `data/indicator_support_by_indicator.csv` — each of the ~144 OCDS indicators with how many
+  datasets can compute it (supported / well-supported) and whether Cardinal implements it.
+- `data/indicator_support_by_dataset.csv` — each dataset with how many usability / red-flag
+  indicators it well-supports (the comprehensive dataset-selection metric).
+
+See [FINDINGS.md](FINDINGS.md) for the interpretation and schema implications.

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -42,4 +42,6 @@ is downloaded or generated and is git-ignored.
 - `data/indicator_support_by_dataset.csv` — each dataset with how many usability / red-flag
   indicators it well-supports (the comprehensive dataset-selection metric).
 
-See [FINDINGS.md](FINDINGS.md) for the interpretation and schema implications.
+See [FINDINGS.md](FINDINGS.md) for the interpretation and schema implications, and
+[COMPARISONS.md](COMPARISONS.md) for how the schema compares to OpenTender and Kingfisher
+Summarize (notes for a future blog post).

--- a/analysis/analyze.py
+++ b/analysis/analyze.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Assess OCDS array fields across the whole Data Registry corpus.
+
+For every array path (coverage key ending in `[]`) we compute, aggregated across all
+publications that report coverage:
+  - breadth : number of datasets in which the array appears
+  - presence : fraction of immediate-parent objects that carry a non-empty array
+  - cardinality : mean elements per non-empty occurrence (corpus + per-dataset median/max)
+Arrays not defined by OCDS core or a registered extension are reported separately.
+
+Reads data/publications.json + data/schema_arrays.json (run download.py, then schema_arrays.py,
+first). Writes data/assessment.csv and data/assessment.json.
+"""
+
+import csv
+import json
+import statistics
+from pathlib import Path
+
+DATA = Path(__file__).parent / "data"
+
+
+def container(arr_path):
+    return arr_path[:-2]  # strip trailing "[]"
+
+
+def parent_of(cont):
+    return cont.rsplit("/", 1)[0] if "/" in cont else ""
+
+
+def aggregate(arr_path, covs):
+    cont = container(arr_path)
+    par = parent_of(cont)
+    elems_tot = cont_tot = par_tot = proc_tot = datasets = 0
+    per_ds_card = []
+    for c in covs:
+        e = c.get(arr_path, 0)
+        if e == 0:
+            continue
+        datasets += 1
+        ct = c.get(cont, 0)
+        elems_tot += e
+        cont_tot += ct
+        par_tot += c.get(par, 0)
+        proc_tot += c.get("", 0)
+        if ct:
+            per_ds_card.append(e / ct)
+    return {
+        "datasets": datasets,
+        "card_corpus": (elems_tot / cont_tot) if cont_tot else None,
+        "card_median": statistics.median(per_ds_card) if per_ds_card else None,
+        "card_max": max(per_ds_card) if per_ds_card else None,
+        "presence": (cont_tot / par_tot) if par_tot else None,
+        "elems_per_process": (elems_tot / proc_tot) if proc_tot else None,
+    }
+
+
+def main():
+    pubs = json.load(open(DATA / "publications.json"))
+    schema = json.load(open(DATA / "schema_arrays.json"))
+    covs = [p["coverage"] for p in pubs if p.get("coverage")]
+    total_processes = sum(c.get("", 0) for c in covs)
+
+    observed = set()
+    for c in covs:
+        observed.update(k for k in c if k.endswith("[]"))
+
+    rows = []
+    for p in sorted(observed):
+        a = aggregate(p, covs)
+        a["path"] = p
+        a["in_schema"] = p in schema
+        a["source"] = schema.get(p, {}).get("source", "NOT-IN-SCHEMA")
+        rows.append(a)
+
+    json.dump(rows, open(DATA / "assessment.json", "w"), indent=1)
+    with open(DATA / "assessment.csv", "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(
+            [
+                "path",
+                "source",
+                "datasets",
+                "presence_pct",
+                "card_corpus",
+                "card_median",
+                "card_max",
+                "elems_per_process",
+            ]
+        )
+        for r in sorted(rows, key=lambda r: (not r["in_schema"], -r["datasets"])):
+            w.writerow(
+                [
+                    r["path"],
+                    r["source"],
+                    r["datasets"],
+                    round(r["presence"] * 100, 1) if r["presence"] is not None else "",
+                    round(r["card_corpus"], 3) if r["card_corpus"] is not None else "",
+                    round(r["card_median"], 3) if r["card_median"] is not None else "",
+                    round(r["card_max"], 1) if r["card_max"] is not None else "",
+                    round(r["elems_per_process"], 3) if r["elems_per_process"] is not None else "",
+                ]
+            )
+
+    in_schema = [r for r in rows if r["in_schema"]]
+    junk = [r for r in rows if not r["in_schema"]]
+    print(f"publications with coverage : {len(covs)}")
+    print(f"total contracting processes: {total_processes:,}")
+    print(f"distinct array paths observed: {len(rows)}  (in-schema {len(in_schema)}, non-schema {len(junk)})")
+
+    def fmt(r):
+        line = f"{r['path']:<52} ds={r['datasets']:>3}  card~{r['card_corpus']:>5.2f}"
+        if r["card_median"] is not None:
+            line += f" (med {r['card_median']:.2f}, max {r['card_max']:,.0f})"
+        if r["presence"] is not None:
+            line += f"  presence={r['presence'] * 100:>5.1f}%"
+        return line
+
+    print("\n===== IN-SCHEMA ARRAYS, by breadth (datasets present) =====")
+    for r in sorted(in_schema, key=lambda r: (-r["datasets"], -(r["card_corpus"] or 0))):
+        print(fmt(r), f"[{r['source']}]")
+
+    print("\n===== NON-SCHEMA ARRAYS (publisher-specific; candidates to ignore) =====")
+    for r in sorted(junk, key=lambda r: -r["datasets"])[:40]:
+        print(fmt(r))
+    print(f"... {len(junk)} non-schema array paths total")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/download.py
+++ b/analysis/download.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Download the public inputs the assessment needs (idempotent; skips existing files).
+
+- publications.json      : every Data Registry dataset + its Cardinal `coverage` output
+- extensions.json        : the registered-extension registry
+- core-release-schema.json : OCDS 1.1 core release schema
+"""
+
+import urllib.request
+from pathlib import Path
+
+DATA = Path(__file__).parent / "data"
+
+KFC = "https://raw.githubusercontent.com/open-contracting/kingfisher-colab/315feecc8582d25e1a4efd3540dc1c06e66a2585/ocdskingfishercolab/indicators/"
+SOURCES = {
+    "publications.json": "https://data.open-contracting.org/publications.json",
+    "extensions.json": "https://extensions.open-contracting.org/extensions.json",
+    "core-release-schema.json": "https://standard.open-contracting.org/1.1/en/release-schema.json",
+    # Kingfisher-Colab indicator catalogue (pinned commit) + its schema
+    "indicators.json": KFC + "indicators.json",
+    "indicators.schema.json": KFC + "indicators.schema.json",
+}
+
+
+def main():
+    DATA.mkdir(exist_ok=True)
+    for name, url in SOURCES.items():
+        dest = DATA / name
+        if dest.exists():
+            print(f"cached   {name}")
+            continue
+        with urllib.request.urlopen(url, timeout=60) as r:
+            dest.write_bytes(r.read())
+        print(f"fetched  {name}  ({dest.stat().st_size:,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/fetch_ext_schemas.py
+++ b/analysis/fetch_ext_schemas.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Fetch each registered extension's release-schema.json patch into data/ext_cache/."""
+
+import concurrent.futures as cf
+import json
+import urllib.request
+from pathlib import Path
+
+DATA = Path(__file__).parent / "data"
+CACHE = DATA / "ext_cache"
+
+
+def latest_version(e):
+    lv = e.get("latest_version")
+    return e["versions"].get(lv) or list(e["versions"].values())[-1]
+
+
+def fetch(target):
+    eid, url = target
+    dest = CACHE / f"{eid}.json"
+    if dest.exists():
+        return (eid, "cached")
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r:
+            data = r.read()
+        json.loads(data)  # validate
+        dest.write_bytes(data)
+        return (eid, "ok")
+    except Exception as e:
+        return (eid, f"MISS ({type(e).__name__})")
+
+
+def main():
+    CACHE.mkdir(parents=True, exist_ok=True)
+    ext = json.load(open(DATA / "extensions.json"))
+    targets = [(eid, latest_version(e)["base_url"].rstrip("/") + "/release-schema.json") for eid, e in ext.items()]
+
+    with cf.ThreadPoolExecutor(max_workers=12) as ex:
+        results = list(ex.map(fetch, targets))
+
+    ok = [r for r in results if r[1] in ("ok", "cached")]
+    miss = [r for r in results if r[1].startswith("MISS")]
+    print(f"schemas fetched/cached: {len(ok)}/{len(targets)}")
+    print(f"no release-schema.json (codelist/doc-only extensions): {len(miss)}")
+    for r in miss:
+        print("   -", r[0], r[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/indicator_support.py
+++ b/analysis/indicator_support.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Assess each dataset against the full OCDS indicator catalogue (not just single-bid).
+
+Input: the Kingfisher-Colab indicator definitions (indicators.json) — ~72 usability (U###)
+and ~73 red-flag (R###) indicators, each with a rule tree of required OCDS field paths using
+all / any / ref logic. We map each field path to a Cardinal `coverage` path (inserting `[]`
+at array levels, driven by the schema + observed array paths), then evaluate every rule tree
+against every dataset's published coverage.
+
+Two notions of "support":
+  - supported (bool)  : every required field appears at all (coverage > 0) — the publisher
+                        could ever compute the indicator.
+  - score (0..1)      : evaluate the tree with leaf = per-process coverage fraction,
+                        all = min, any = max. An upper bound on the share of contracting
+                        processes for which the indicator is actually computable. (Coverage is
+                        marginal per field, so the true joint share is <= this.)
+  - well-supported    : score >= STRONG (default 0.5).
+
+Reads data/publications.json + data/schema_arrays.json + data/indicators.json (run download.py,
+then schema_arrays.py, first). Outputs data/indicator_support_by_indicator.csv and
+data/indicator_support_by_dataset.csv.
+"""
+
+import csv
+import json
+from pathlib import Path
+
+DATA = Path(__file__).parent / "data"
+STRONG = 0.5
+MIN_PROCESSES = 500
+
+# Red-flag indicators Cardinal implements today (src/lib.rs imports R003, R018, ...).
+CARDINAL_IMPLEMENTED = {"R003", "R018", "R024", "R025", "R028", "R030", "R035", "R036", "R038", "R048", "R058"}
+
+
+def array_path_set():
+    """
+    Authoritative array paths (OCDS core + registered extensions) for [] placement.
+
+    Deliberately schema-only: a malformed publisher array (e.g. one publisher emitting
+    `/bids[]` instead of the object `/bids`) must not shift where we insert [], or it would
+    corrupt the mapping for every dataset. Every indicator field is a core/extension field,
+    so the schema set covers them all.
+    """
+    return set(json.load(open(DATA / "schema_arrays.json")))
+
+
+def to_coverage_path(field, arrays):
+    """
+    Map an indicator field path (e.g. awards/suppliers/id) to coverage format
+    (/awards[]/suppliers[]/id) by appending [] wherever the prefix is a known array.
+    """
+    prefix = ""
+    for seg in field.split("/"):
+        prefix += "/" + seg
+        if prefix + "[]" in arrays:
+            prefix += "[]"
+    return prefix
+
+
+def build_evaluator(indicators_doc, arrays):
+    rules = indicators_doc.get("rules", {})
+    # cache the field->coverage-path mapping
+    field_cache = {}
+
+    def cov_path(field):
+        if field not in field_cache:
+            field_cache[field] = to_coverage_path(field, arrays)
+        return field_cache[field]
+
+    def score(rule, leaf):
+        if isinstance(rule, str):
+            return leaf(cov_path(rule))
+        if "ref" in rule:
+            return score(rules[rule["ref"]], leaf)
+        if "all" in rule:
+            return min(score(r, leaf) for r in rule["all"])
+        if "any" in rule:
+            return max(score(r, leaf) for r in rule["any"])
+        raise ValueError(f"bad rule: {rule!r}")
+
+    def required_fields(rule, acc):
+        if isinstance(rule, str):
+            acc.add(rule)
+        elif "ref" in rule:
+            required_fields(rules[rule["ref"]], acc)
+        else:
+            for r in rule.get("all", []) + rule.get("any", []):
+                required_fields(r, acc)
+        return acc
+
+    return score, required_fields, cov_path
+
+
+def main():
+    arrays = array_path_set()
+    doc = json.load(open(DATA / "indicators.json"))
+    indicators = doc["indicators"]
+    score_fn, required_fields, cov_path = build_evaluator(doc, arrays)
+
+    pubs = [
+        p for p in json.load(open(DATA / "publications.json")) if (p.get("coverage") or {}).get("", 0) >= MIN_PROCESSES
+    ]
+
+    def make_leaf(cov):
+        n = cov.get("", 0)
+
+        def leaf(path):
+            # for a terminal-array path the [] element key equals presence; clamp cardinality
+            return min(cov.get(path, 0) / n, 1.0) if n else 0.0
+
+        return leaf
+
+    per_ind = {iid: {"supported": 0, "strong": 0, "score_sum": 0.0} for iid in indicators}
+    per_ds = []
+    for p in pubs:
+        cov = p["coverage"]
+        leaf = make_leaf(cov)
+        u_strong = r_strong = u_sup = r_sup = 0
+        score_sum = 0.0
+        for iid, ind in indicators.items():
+            s = score_fn(ind["rule"], leaf)
+            supported = s > 0
+            strong = s >= STRONG
+            per_ind[iid]["score_sum"] += s
+            per_ind[iid]["supported"] += supported
+            per_ind[iid]["strong"] += strong
+            score_sum += s
+            if iid[0] == "U":
+                u_sup += supported
+                u_strong += strong
+            else:
+                r_sup += supported
+                r_strong += strong
+        per_ds.append(
+            {
+                "id": p["id"],
+                "country": p.get("country", ""),
+                "language": p.get("language", ""),
+                "region": p.get("region", ""),
+                "processes": cov.get("", 0),
+                "U_strong": u_strong,
+                "R_strong": r_strong,
+                "total_strong": u_strong + r_strong,
+                "U_supported": u_sup,
+                "R_supported": r_sup,
+                "total_supported": u_sup + r_sup,
+                "mean_score": round(score_sum / len(indicators), 3),
+                "title": p["title"][:44],
+            }
+        )
+
+    n_ds = len(pubs)
+    n_u = sum(1 for i in indicators if i[0] == "U")
+    n_r = sum(1 for i in indicators if i[0] == "R")
+
+    # by-indicator CSV
+    ind_rows = []
+    for iid, ind in indicators.items():
+        st = per_ind[iid]
+        ind_rows.append(
+            {
+                "indicator": iid,
+                "type": "usability" if iid[0] == "U" else "red_flag",
+                "name": ind["name"],
+                "cardinal_implemented": iid in CARDINAL_IMPLEMENTED,
+                "num_required_fields": len(required_fields(ind["rule"], set())),
+                "datasets_supported": st["supported"],
+                "pct_datasets_supported": round(st["supported"] / n_ds * 100, 1),
+                "datasets_well_supported": st["strong"],
+                "mean_score": round(st["score_sum"] / n_ds, 3),
+            }
+        )
+    ind_rows.sort(key=lambda r: (-r["datasets_well_supported"], -r["datasets_supported"]))
+    with open(DATA / "indicator_support_by_indicator.csv", "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(ind_rows[0].keys()))
+        w.writeheader()
+        w.writerows(ind_rows)
+
+    per_ds.sort(key=lambda r: (-r["total_strong"], -r["total_supported"]))
+    with open(DATA / "indicator_support_by_dataset.csv", "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(per_ds[0].keys()))
+        w.writeheader()
+        w.writerows(per_ds)
+
+    # ---- console report ----
+    print(
+        f"indicators: {len(indicators)}  ({n_u} usability, {n_r} red-flag)  |  Cardinal implements {len(CARDINAL_IMPLEMENTED)} red flags"
+    )
+    print(f"datasets assessed (>= {MIN_PROCESSES} processes): {n_ds}")
+    print(f"well-supported = indicator score >= {STRONG} (upper-bound share of processes computable)\n")
+
+    print(f"===== INDICATORS most widely well-supported (of {n_ds} datasets) =====")
+    for r in ind_rows[:20]:
+        flag = " *cardinal" if r["cardinal_implemented"] else ""
+        print(
+            f"  {r['indicator']}  well={r['datasets_well_supported']:>3}  any={r['datasets_supported']:>3}  "
+            f"score~{r['mean_score']:.2f}  {r['name'][:52]}{flag}"
+        )
+
+    print("\n===== INDICATORS least supported (data rarely published) =====")
+    for r in sorted(ind_rows, key=lambda r: (r["datasets_supported"], r["mean_score"]))[:15]:
+        print(
+            f"  {r['indicator']}  well={r['datasets_well_supported']:>3}  any={r['datasets_supported']:>3}  "
+            f"score~{r['mean_score']:.2f}  {r['name'][:52]}"
+        )
+
+    print("\n===== Cardinal's implemented red flags — supportability across the corpus =====")
+    for r in sorted([r for r in ind_rows if r["cardinal_implemented"]], key=lambda r: -r["datasets_well_supported"]):
+        print(
+            f"  {r['indicator']}  well={r['datasets_well_supported']:>3}  any={r['datasets_supported']:>3}  "
+            f"score~{r['mean_score']:.2f}  {r['name'][:52]}"
+        )
+
+    print(f"\n===== DATASETS by well-supported indicators (U/{n_u}, R/{n_r}) =====")
+    hdr = f"  {'id':>4} {'country':<14}{'lang':<10}{'proc':>10}  U_well R_well  tot  score"
+    print(hdr)
+    for r in per_ds[:15]:
+        print(
+            f"  {r['id']:>4} {r['country'][:13]:<14}{r['language'][:9]:<10}{r['processes']:>10,}  "
+            f"{r['U_strong']:>5} {r['R_strong']:>6} {r['total_strong']:>4}  {r['mean_score']:.2f}   {r['title']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/schema_arrays.py
+++ b/analysis/schema_arrays.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Enumerate every array path defined by OCDS 1.1 core + all registered extensions,
+in Cardinal `coverage` path format (e.g. /awards[]/items[]/additionalClassifications[]).
+
+Reads data/core-release-schema.json + data/ext_cache/*.json (run download.py, then
+fetch_ext_schemas.py, first). Writes data/schema_arrays.json: {path: {"source": "core"|"extension"}}.
+"""
+
+import glob
+import json
+import os
+from pathlib import Path
+
+DATA = Path(__file__).parent / "data"
+
+
+def merge_patch(target, patch):
+    """RFC 7396 JSON Merge Patch (OCDS extension release-schema.json semantics)."""
+    if not isinstance(patch, dict):
+        return patch
+    if not isinstance(target, dict):
+        target = {}
+    for k, v in patch.items():
+        if v is None:
+            target.pop(k, None)
+        elif isinstance(v, dict):
+            target[k] = merge_patch(target.get(k), v)
+        else:
+            target[k] = v
+    return target
+
+
+def load_ext_patches():
+    patches = {}
+    for f in sorted(glob.glob(str(DATA / "ext_cache" / "*.json"))):
+        eid = os.path.splitext(os.path.basename(f))[0]
+        patches[eid] = json.load(open(f))
+    return patches
+
+
+def types_of(node):
+    t = node.get("type")
+    if t is None:
+        return set()
+    return set(t) if isinstance(t, list) else {t}
+
+
+def enumerate_arrays(schema):
+    """
+    Return set of array paths (coverage format). Resolves local $refs; guards recursion
+    by the set of definition names already on the current branch.
+    """
+    defs = schema.get("definitions", {})
+    arrays = set()
+
+    def resolve(node):
+        if isinstance(node, dict) and "$ref" in node:
+            ref = node["$ref"]
+            if ref.startswith("#/definitions/"):
+                name = ref.split("/")[-1]
+                return defs.get(name, {}), name
+            return {}, None  # external ref: treat as opaque
+        return node, None
+
+    def walk(node, prefix, stack):
+        if len(prefix) > 200:  # runaway guard
+            return
+        node, _ = resolve(node)
+        if not isinstance(node, dict):
+            return
+        branches = [node] + [s for kw in ("oneOf", "anyOf", "allOf") for s in node.get(kw, [])]
+        for b in branches:
+            b, _ = resolve(b)
+            if not isinstance(b, dict):
+                continue
+            ts = types_of(b)
+            if "array" in ts and "items" in b:
+                apath = prefix + "[]"
+                arrays.add(apath)
+                items = b["items"]
+                _, iref = resolve(items)
+                if iref and iref in stack:
+                    continue
+                walk(items, apath, stack | ({iref} if iref else set()))
+            if "object" in ts or "properties" in b:
+                for pname, pschema in b.get("properties", {}).items():
+                    _, pref = resolve(pschema)
+                    if pref and pref in stack:
+                        continue
+                    walk(pschema, prefix + "/" + pname, stack | ({pref} if pref else set()))
+
+    walk(schema, "", set())
+    return arrays
+
+
+def main():
+    core = json.load(open(DATA / "core-release-schema.json"))
+    core_arrays = enumerate_arrays(core)
+
+    merged = json.loads(json.dumps(core))
+    for patch in load_ext_patches().values():
+        merged = merge_patch(merged, patch)
+    all_arrays = enumerate_arrays(merged)
+
+    result = {p: {"source": "core" if p in core_arrays else "extension"} for p in sorted(all_arrays)}
+    json.dump(result, open(DATA / "schema_arrays.json", "w"), indent=0)
+
+    print(f"total schema array paths (core+ext): {len(result)}")
+    print(f"  core:           {len(core_arrays)}")
+    print(f"  extension-only: {len(all_arrays - core_arrays)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/select_datasets.py
+++ b/analysis/select_datasets.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Rank datasets by coverage of the fields the chatbot POC needs, to pick a good subset.
+
+Coverage of a field in a dataset = count(field) / count("") = fraction of contracting
+processes for which the field is non-empty (from the published Cardinal `coverage`).
+
+We score three question themes plus a core-identity group, then rank. A dataset is a strong
+POC candidate when it covers the core fields AND supports several themes; language/region are
+shown so a contrasting pair/subset can be chosen.
+
+Reads data/publications.json (run download.py first). Writes data/dataset_scores.csv.
+"""
+
+import csv
+import json
+from pathlib import Path
+
+DATA = Path(__file__).parent / "data"
+
+# field groups (coverage path -> weight); themes gate whether a question is answerable
+CORE = {
+    "/buyer/name": 1,
+    "/tender/procurementMethod": 1,
+    "/tender/procurementMethodDetails": 1,
+    "/tender/mainProcurementCategory": 1,
+    "/tender/title": 1,
+}
+MONEY_SUPPLIER = {  # top-suppliers / price-deviation themes
+    "/awards[]/value/amount": 1,
+    "/awards[]/value/currency": 1,
+    "/awards[]/suppliers[]/name": 1,
+    "/awards[]/date": 1,
+}
+SINGLE_BID = {  # R018 keys on the scalar numberOfTenderers; bids/details is a fallback signal
+    "/tender/numberOfTenderers": 1,
+    "/bids/details[]": 1,
+}
+AMENDMENTS = {
+    "/contracts[]/amendments[]": 1,
+    "/tender/amendments[]": 1,
+}
+ALL_FIELDS = {**CORE, **MONEY_SUPPLIER, **SINGLE_BID, **AMENDMENTS}
+
+MIN_PROCESSES = 500  # ignore toy datasets
+THEME_THRESHOLD = 0.10  # a theme is "supported" if its best field covers >=10% of processes
+
+
+def cov(c, path):
+    """
+    Fraction of contracting processes where the field is present, in [0, 1].
+
+    For array paths (`.../x[]`) we count the container (`.../x`, i.e. processes/parents with a
+    non-empty array), not the element count, and clamp: element counts exceed the process count
+    when a process has several awards/bids, which is cardinality, not coverage.
+    """
+    n = c.get("", 0)
+    if not n:
+        return 0.0
+    key = path.removesuffix("[]")
+    return min(c.get(key, 0) / n, 1.0)
+
+
+def theme_best(c, fields):
+    return max((cov(c, f) for f in fields), default=0.0)
+
+
+def main():
+    pubs = json.load(open(DATA / "publications.json"))
+    rows = []
+    for p in pubs:
+        c = p.get("coverage") or {}
+        n = c.get("", 0)
+        if n < MIN_PROCESSES:
+            continue
+        core = sum(cov(c, f) for f in CORE) / len(CORE)
+        money = theme_best(c, MONEY_SUPPLIER)
+        sbid = theme_best(c, SINGLE_BID)
+        amend = theme_best(c, AMENDMENTS)
+        themes = sum(x >= THEME_THRESHOLD for x in (money, sbid, amend))
+        # overall: core identity must be strong; themes broaden usefulness
+        score = round(0.5 * core + 0.5 * (money + sbid + amend) / 3, 3)
+        rows.append(
+            {
+                "id": p["id"],
+                "title": p["title"][:44],
+                "country": p.get("country", ""),
+                "language": p.get("language", ""),
+                "region": p.get("region", ""),
+                "processes": n,
+                "core": round(core, 2),
+                "money_supplier": round(money, 2),
+                "single_bid": round(sbid, 2),
+                "amendments": round(amend, 2),
+                "themes": themes,
+                "score": score,
+                "numberOfTenderers": round(cov(c, "/tender/numberOfTenderers"), 2),
+            }
+        )
+
+    rows.sort(key=lambda r: (-r["themes"], -r["score"]))
+    with open(DATA / "dataset_scores.csv", "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+    print(f"datasets with >= {MIN_PROCESSES} processes: {len(rows)}\n")
+    hdr = f"{'id':>4} {'country':<14} {'lang':<10} {'proc':>10}  core money sbid amnd  #th  score  nTend"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows[:15]:
+        print(
+            f"{r['id']:>4} {r['country'][:13]:<14} {r['language'][:9]:<10} {r['processes']:>10,}  "
+            f"{r['core']:>4} {r['money_supplier']:>4} {r['single_bid']:>4} {r['amendments']:>4}  "
+            f"{r['themes']:>3}  {r['score']:>5}  {r['numberOfTenderers']:>4}   {r['title']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/opentender.md
+++ b/opentender.md
@@ -1,0 +1,214 @@
+# CSV data description
+
+Bulk tender CSV uses semicolon (;) delimiters, UTF-8 encoding, and one row per combination of buyer × lot × bid × bidder. 
+
+Dates are YYYY/MM/DD. Boolean fields use yes/no. Price groups expand to national net amount, currency, optional min/max range, and EUR. 
+
+Tender rows repeat for each nested combination; empty nested entities yield blank cells in those columns. 
+
+Indicator columns follow the schema enum in opentender-data. 
+
+## Tender
+
+| Column | Description |
+| :--- | :--- |
+| `tender_row_nr` | Row index for this tender within the export batch (1-based). |
+| `tender_id` | Stable tender identifier in OpenTender. |
+| `tender_country` | ISO-style country code for the portal source. |
+| `tender_title` | Tender title as published. |
+| `tender_size` | Estimated contract size band or classification when available. |
+| `tender_supplyType` | Supply type (works, services, supplies, etc.) when coded. |
+| `tender_procedureType` | Procurement procedure type (open, restricted, negotiated, etc.). |
+| `tender_nationalProcedureType` | National procedure classification when provided. |
+| `tender_mainCpv` | Main CPV code (single code marked as main in source data). |
+| `tender_cpvs` | Comma-separated list of all CPV codes on the tender. |
+| `tender_addressOfImplementation_nuts` | Comma-separated NUTS region codes for place of performance. |
+| `tender_addressOfImplementation_country` | Country for place of performance. |
+| `tender_addressOfImplementation_postcode` | Postcode for place of performance. |
+| `tender_addressOfImplementation_city` | City for place of performance (column name matches CSV header, including trailing space). |
+| `tender_addressOfImplementation_street` | Street address for place of performance (column name matches CSV header, including trailing space). |
+| `tender_year` | Four-digit year derived from OpenTender processing date (\`ot.date\`). |
+| `tender_fundingProgrammes` | Comma-separated EU or other funding programme names linked to the tender. |
+| `tender_eligibleBidLanguages` | Comma-separated languages in which bids may be submitted. |
+| `tender_npwp_reasons` | Comma-separated non-price weighting / award-criteria reasons when present. |
+| `tender_awardDeadline` | Award decision deadline (YYYY/MM/DD). |
+| `tender_contractSignatureDate` | Contract signature date (YYYY/MM/DD). |
+| `tender_awardDecisionDate` | Award decision date (YYYY/MM/DD). |
+| `tender_bidDeadline` | Bid submission deadline (YYYY/MM/DD). |
+| `tender_cancellationDate` | Cancellation date if the procedure was cancelled (YYYY/MM/DD). |
+| `tender_estimatedStartDate` | Estimated contract start (YYYY/MM/DD). |
+| `tender_estimatedCompletionDate` | Estimated contract end (YYYY/MM/DD). |
+| `tender_estimatedDurationInYears` | Estimated duration in years (numeric). |
+| `tender_estimatedDurationInMonths` | Estimated duration in months (numeric). |
+| `tender_estimatedDurationInDays` | Estimated duration in days (numeric). |
+| `tender_isEUFunded` | Whether EU funding is linked (\`yes\` / \`no\`). |
+| `tender_isDps` | Dynamic purchasing system flag (\`yes\` / \`no\`). |
+| `tender_isElectronicAuction` | Electronic auction used (\`yes\` / \`no\`). |
+| `tender_isAwarded` | Tender has at least one award (\`yes\` / \`no\`). |
+| `tender_isCentralProcurement` | Central purchasing body (\`yes\` / \`no\`). |
+| `tender_isJointProcurement` | Joint procurement between buyers (\`yes\` / \`no\`). |
+| `tender_isOnBehalfOf` | Procurement on behalf of another authority (\`yes\` / \`no\`). |
+| `tender_isFrameworkAgreement` | Framework agreement (\`yes\` / \`no\`). |
+| `tender_isCoveredByGpa` | Covered by GPA (\`yes\` / \`no\`). |
+| `tender_hasLots` | Tender divided into lots (\`yes\` / \`no\`). |
+| `tender_estimatedPrice` | Estimated value: net amount in national currency. |
+| `tender_estimatedPrice_currency` | Estimated value: national currency code. |
+| `tender_estimatedPrice_minNetAmount` | Estimated value: minimum net amount when a range is given. |
+| `tender_estimatedPrice_maxNetAmount` | Estimated value: maximum net amount when a range is given. |
+| `tender_estimatedPrice_EUR` | Estimated value: net amount converted to EUR when available. |
+| `tender_finalPrice` | Final / awarded value: net amount in national currency. |
+| `tender_finalPrice_currency` | Final value: national currency code. |
+| `tender_finalPrice_minNetAmount` | Final value: minimum net amount when a range is given. |
+| `tender_finalPrice_maxNetAmount` | Final value: maximum net amount when a range is given. |
+| `tender_finalPrice_EUR` | Final value: net amount in EUR when available. |
+| `tender_description` | Full tender description text. |
+| `tender_description_length` | Character length of the tender description. |
+| `tender_personalRequirements_length` | Character length of personal suitability requirements text. |
+| `tender_economicRequirements_length` | Character length of economic / financial requirements text. |
+| `tender_technicalRequirements_length` | Character length of technical requirements text. |
+| `tender_documents_count` | Number of document objects attached to the tender. |
+| `tender_awardCriteria_count` | Number of award criteria entries. |
+| `tender_corrections_count` | Number of correction notices linked to the tender. |
+| `tender_onBehalfOf_count` | Number of on-behalf-of relationships. |
+| `tender_lots_count` | Number of lots. |
+| `tender_publications_count` | Number of publication entries. |
+| `tender_publications_firstCallForTenderDate` | Earliest contract-notice publication date (YYYY/MM/DD). |
+| `tender_publications_lastCallForTenderDate` | Latest contract-notice publication date (YYYY/MM/DD). |
+| `tender_publications_firstdContractAwardDate` | Earliest contract-award publication date (YYYY/MM/DD). Note the typo \`firstd\` in the column name matches the export. |
+| `tender_publications_lastContractAwardDate` | Latest contract-award publication date (YYYY/MM/DD). |
+| `tender_publications_lastContractAwardUrl` | Human-readable URL of the latest contract-award notice when available. |
+| `tender_buyerAssignedId` | Buyer-assigned reference ID (column name matches CSV header, including trailing space). |
+| `tender_indicator_INTEGRITY_SINGLE_BID` | Tender-level indicator score for \`INTEGRITY\_SINGLE\_BID\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_CALL_FOR_TENDER_PUBLICATION` | Tender-level indicator score for \`INTEGRITY\_CALL\_FOR\_TENDER\_PUBLICATION\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_ADVERTISEMENT_PERIOD` | Tender-level indicator score for \`INTEGRITY\_ADVERTISEMENT\_PERIOD\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_PROCEDURE_TYPE` | Tender-level indicator score for \`INTEGRITY\_PROCEDURE\_TYPE\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_DECISION_PERIOD` | Tender-level indicator score for \`INTEGRITY\_DECISION\_PERIOD\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_TAX_HAVEN` | Tender-level indicator score for \`INTEGRITY\_TAX\_HAVEN\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_NEW_COMPANY` | Tender-level indicator score for \`INTEGRITY\_NEW\_COMPANY\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_DESCRIPTION_LENGTH` | Tender-level indicator score for \`INTEGRITY\_DESCRIPTION\_LENGTH\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_SIGNATURE_PERIOD` | Tender-level indicator score for \`INTEGRITY\_SIGNATURE\_PERIOD\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_WINNER_CONTRACT_SHARE` | Tender-level indicator score for \`INTEGRITY\_WINNER\_CONTRACT\_SHARE\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_POLITICAL_CONNECTIONS` | Tender-level indicator score for \`INTEGRITY\_POLITICAL\_CONNECTIONS\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_BUYER_CONCENTRATION` | Tender-level indicator score for \`INTEGRITY\_BUYER\_CONCENTRATION\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_SUPPLIER_SHARE_IN_BUYER_SPENDING` | Tender-level indicator score for \`INTEGRITY\_SUPPLIER\_SHARE\_IN\_BUYER\_SPENDING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_BENFORDS_LAW_FOR_BID_PRICES` | Tender-level indicator score for \`INTEGRITY\_BENFORDS\_LAW\_FOR\_BID\_PRICES\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_DISTINCT_MARKET` | Tender-level indicator score for \`INTEGRITY\_DISTINCT\_MARKET\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_ADMINISTRATIVE_CENTRALIZED_PROCUREMENT` | Tender-level indicator score for \`ADMINISTRATIVE\_CENTRALIZED\_PROCUREMENT\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_ADMINISTRATIVE_ELECTRONIC_AUCTION` | Tender-level indicator score for \`ADMINISTRATIVE\_ELECTRONIC\_AUCTION\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_ADMINISTRATIVE_COVERED_BY_GPA` | Tender-level indicator score for \`ADMINISTRATIVE\_COVERED\_BY\_GPA\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_ADMINISTRATIVE_FRAMEWORK_AGREEMENT` | Tender-level indicator score for \`ADMINISTRATIVE\_FRAMEWORK\_AGREEMENT\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_ADMINISTRATIVE_ENGLISH_AS_FOREIGN_LANGUAGE` | Tender-level indicator score for \`ADMINISTRATIVE\_ENGLISH\_AS\_FOREIGN\_LANGUAGE\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_ADMINISTRATIVE_NOTICE_AND_AWARD_DISCREPANCIES` | Tender-level indicator score for \`ADMINISTRATIVE\_NOTICE\_AND\_AWARD\_DISCREPANCIES\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_NUMBER_OF_KEY_MISSING_FIELDS` | Tender-level indicator score for \`TRANSPARENCY\_NUMBER\_OF\_KEY\_MISSING\_FIELDS\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_AWARD_DATE_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_AWARD\_DATE\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_BUYER_NAME_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_BUYER\_NAME\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_PROC_METHOD_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_PROC\_METHOD\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_BUYER_LOC_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_BUYER\_LOC\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_BIDDER_ID_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_BIDDER\_ID\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_BIDDER_NAME_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_BIDDER\_NAME\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MARKET_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_MARKET\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_TITLE_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_TITLE\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_VALUE_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_VALUE\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_YEAR_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_YEAR\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_WINNER_CA_SHARE` | Tender-level indicator score for \`INTEGRITY\_WINNER\_CA\_SHARE\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_NR_OF_REQUESTED_BIDS` | Tender-level indicator score for \`INTEGRITY\_NR\_OF\_REQUESTED\_BIDS\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_CA_TYPE_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_CA\_TYPE\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_IMP_LOC_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_IMP\_LOC\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_BID_NR_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_BID\_NR\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_HEADOFENTITY_DATE_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_HEADOFENTITY\_DATE\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_COMMITTEE_DATE_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_COMMITTEE\_DATE\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MISSING_OR_INCOMPLETE_AWARD_CRITERIA` | Tender-level indicator score for \`TRANSPARENCY\_MISSING\_OR\_INCOMPLETE\_AWARD\_CRITERIA\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MISSING_ELIGIBLE_BID_LANGUAGES` | Tender-level indicator score for \`TRANSPARENCY\_MISSING\_ELIGIBLE\_BID\_LANGUAGES\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MISSING_OR_INCOMPLETE_FUNDINGS_INFO` | Tender-level indicator score for \`TRANSPARENCY\_MISSING\_OR\_INCOMPLETE\_FUNDINGS\_INFO\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MISSING_OR_INCOMPLETE_DURATION_INFO` | Tender-level indicator score for \`TRANSPARENCY\_MISSING\_OR\_INCOMPLETE\_DURATION\_INFO\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MISSING_SUBCONTRACTED_INFO` | Tender-level indicator score for \`TRANSPARENCY\_MISSING\_SUBCONTRACTED\_INFO\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MISSING_ADDRESS_OF_IMPLEMENTATION_NUTS` | Tender-level indicator score for \`TRANSPARENCY\_MISSING\_ADDRESS\_OF\_IMPLEMENTATION\_NUTS\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MISSING_OR_INCOMPLETE_CPVS` | Tender-level indicator score for \`TRANSPARENCY\_MISSING\_OR\_INCOMPLETE\_CPVS\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_MISSING_SELECTION_METHOD` | Tender-level indicator score for \`TRANSPARENCY\_MISSING\_SELECTION\_METHOD\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_TRANSPARENCY_SIGN_DATE_MISSING` | Tender-level indicator score for \`TRANSPARENCY\_SIGN\_DATE\_MISSING\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_CONTRACT_MODIFICATION` | Tender-level indicator score for \`INTEGRITY\_CONTRACT\_MODIFICATION\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_MULTIPLE_VALID_BIDS` | Tender-level indicator score for \`INTEGRITY\_MULTIPLE\_VALID\_BIDS\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+| `tender_indicator_INTEGRITY_TEXT_BASED_OPENNESS` | Tender-level indicator score for \`INTEGRITY\_TEXT\_BASED\_OPENNESS\` (0–100 when computed, empty otherwise). Integrity, transparency, and administrative indicators are defined in the OpenTender schema. |
+
+## Buyer (contracting authority)
+
+| Column | Description |
+| :--- | :--- |
+| `buyer_row_nr` | Row index for the buyer on this CSV line (1-based within buyer list for the tender). |
+| `buyer_buyerType` | Type of contracting authority when coded. |
+| `buyer_mainActivities` | Comma-separated main activity codes. |
+| `buyer_bodyIds` | Comma-separated external body identifiers linked to the buyer. |
+| `buyer_id` | OpenTender buyer / authority organisation id. |
+| `buyer_name` | Buyer legal name. |
+| `buyer_nuts` | Comma-separated NUTS codes from the buyer address. |
+| `buyer_city` | Buyer city. |
+| `buyer_country` | Buyer country code from address. |
+| `buyer_postcode` | Buyer postcode. |
+
+## Lot
+
+| Column | Description |
+| :--- | :--- |
+| `lot_row_nr` | Row index for the lot on this CSV line (1-based within lots for the tender). |
+| `lot_title` | Lot title. |
+| `lot_selectionMethod` | Lot selection / award method when present. |
+| `lot_lotId` | Lot identifier from source notice. |
+| `lot_status` | Lot status string. |
+| `lot_estimatedCompletionDate` | Lot estimated completion date (YYYY/MM/DD). |
+| `lot_estimatedStartDate` | Lot estimated start date (YYYY/MM/DD). |
+| `lot_contractSignatureDate` | Lot-level contract signature date (YYYY/MM/DD). |
+| `lot_cancellationDate` | Lot cancellation date (YYYY/MM/DD). |
+| `lot_isAwarded` | Lot awarded (\`yes\` / \`no\`). |
+| `lot_estimatedPrice` | Lot estimated net amount in national currency. |
+| `lot_estimatedPrice_currency` | Lot estimated national currency code. |
+| `lot_estimatedPrice_minNetAmount` | Lot estimated minimum net amount. |
+| `lot_estimatedPrice_maxNetAmount` | Lot estimated maximum net amount. |
+| `lot_estimatedPrice_EUR` | Lot estimated net amount in EUR. |
+| `lot_lotNumber` | Sequential lot number when provided. |
+| `lot_bidsCount` | Total bids received for the lot. |
+| `lot_validBidsCount` | Valid bids count. |
+| `lot_smeBidsCount` | Bids from SMEs count. |
+| `lot_electronicBidsCount` | Electronic bids count. |
+| `lot_nonEuMemberStatesCompaniesBidsCount` | Bids from non-EU companies count. |
+| `lot_otherEuMemberStatesCompaniesBidsCount` | Bids from other EU member state companies count. |
+| `lot_foreignCompaniesBidsCount` | Bids from foreign companies count. |
+| `lot_description` | Lot description text. |
+| `lot_description_length` | Character length of lot description. |
+| `lot_fundingProgrammes` | Comma-separated funding programmes on the lot. |
+| `lot_addressOfImplementation_nuts` | Comma-separated NUTS for lot place of performance. |
+| `lot_addressOfImplementation_country` | Country for lot place of performance. |
+| `lot_addressOfImplementation_postcode` | Postcode for lot place of performance. |
+| `lot_addressOfImplementation_city` | City for lot place of performance (trailing space in header matches export). |
+| `lot_addressOfImplementation_street` | Street for lot place of performance (trailing space in header matches export). |
+| `lot_indicator_metadata_decisionPeriodLength` | Comma-separated decision-period metadata from lot-level indicators when present. |
+| `lot_indicator_metadata_bidderGroupId` | Comma-separated bidder-group identifiers from lot-level indicator metadata. |
+
+## Bid
+
+| Column | Description |
+| :--- | :--- |
+| `bid_row_nr` | Row index for the bid on this CSV line (1-based within bids for the lot). |
+| `bid_isWinning` | This bid is the winner (\`yes\` / \`no\`). |
+| `bid_isSubcontracted` | Bid involves subcontracting (\`yes\` / \`no\`). |
+| `bid_isConsortium` | Consortium bid (\`yes\` / \`no\`). |
+| `bid_subcontractedProportion` | Subcontracted proportion when provided (numeric). |
+| `bid_price` | Bid net amount in national currency. |
+| `bid_price_currency` | Bid national currency code. |
+| `bid_price_minNetAmount` | Bid minimum net amount when a range is used. |
+| `bid_price_maxNetAmount` | Bid maximum net amount when a range is used. |
+| `bid_price_EUR` | Bid net amount in EUR. |
+| `bid_subcontractedValue_netAmountEur` | Subcontracted value in EUR when available. |
+| `bid_subcontractedName` | Name of subcontractor when a single name field is stored. |
+
+## Bidder (company)
+
+| Column | Description |
+| :--- | :--- |
+| `bidder_row_nr` | Row index for the bidder on this CSV line (1-based within bidders for the bid). |
+| `bidder_bodyIds` | Comma-separated external body identifiers for the bidder. |
+| `bidder_id` | OpenTender company / bidder organisation id. |
+| `bidder_name` | Bidder legal name. |
+| `bidder_nuts` | Comma-separated NUTS from bidder address. |
+| `bidder_city` | Bidder city. |
+| `bidder_country` | Bidder country from address. |
+| `bidder_postcode` | Bidder postcode. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ ignore-variadic-names = true
 "tests/*" = [
     "ARG001", "D", "FBT003", "INP001", "PLR2004", "S", "TRY003",
 ]
+"analysis/*" = [  # standalone corpus-analysis scripts, not library code
+    "BLE001", "D", "E501", "PLR2004", "PLW2901", "PTH", "RUF059", "S310", "SIM115", "T201", "TRY003", "TRY300",
+]
 
 [tool.uv]
 cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "src/**/*.rs"}]


### PR DESCRIPTION
## What

Reproducible, dependency-free Python (`analysis/`) that mines the Data Registry's published Cardinal `coverage` (via `publications.json`) plus the OCDS 1.1 schema, all registered extensions, and the Kingfisher-Colab indicator catalogue — to put the ML-ready Parquet schema ([#129](https://github.com/open-contracting/cardinal-rs/issues/129)) on an evidence footing instead of guesswork.

The key lever: the registry already publishes `coverage` per dataset, and `coverage` counts array elements (`/awards[]`) separately from the processes containing them (`/awards`), so **array cardinality is derivable without downloading or re-running Cardinal on any bulk data**.

## Scripts (a pipeline; see `analysis/README.md`)

- `download.py` / `fetch_ext_schemas.py` — fetch public inputs (cached, idempotent)
- `schema_arrays.py` — merge OCDS core + all registered extensions (RFC 7396) and enumerate every legitimate array path (49 core + 287 extension)
- `analyze.py` — array cardinality/rarity assessment (1:1 vs genuinely multi vs rare)
- `select_datasets.py` — coarse 3-theme dataset coverage lens
- `indicator_support.py` — assess every dataset against all 144 OCDS indicators (usability + red flag)
- `FINDINGS.md` — interpretation + the finalized **4-table** Parquet schema (`contracting_process`, `award`, `bid`, `lot`), design principles, and per-decision evidence

## Headline findings

- **`single_bid` is data-limited.** R018 as implemented reads only `tender.numberOfTenderers` (24/93 datasets); the indicator *definition* allows bid-based sources, reaching 49/84 — so `single_bid` should fall back to a bid count and be nullable + a coverage flag, not a misleading `0`.
- **Cardinal's 11 red flags are mostly bid-hungry** — only R048/R018/R028/R003 are broadly supportable across the corpus; the rest need detailed `bids/details` data present in ≤2 datasets.
- **Schema:** flatten 1:1 arrays (suppliers→award, tenderers→bid); keep `award`/`bid`/`lot` as their own grains; resolve `parties` lookups (region/identifier) onto rows rather than shipping a parties table; defer `items`. Denormalize dimensions (not measures) into child tables; track every lossy aggregation with a per-row flag + count.
- **Datasets:** evidence-based POC pair is **Rwanda + Paraguay** (+ an OpenTender publisher as a refusal-path contrast). Moldova — in the original draft — has 0 processes in this snapshot.

## Notes

- Everything under `analysis/data/` (downloads + generated CSV/JSON) is git-ignored.
- Adds an `analysis/*` per-file ruff ignore (standalone scripts, not library code), mirroring the existing `tests/*` and `manage.py` entries.
- No changes to Cardinal's Rust/Python library code — this PR is purely the analysis tooling behind the schema decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Jw1FwXo5fzkZeKL9Rjge3
